### PR TITLE
Add coding style

### DIFF
--- a/code_style/intellij/alps_json.xml
+++ b/code_style/intellij/alps_json.xml
@@ -1,0 +1,38 @@
+<code_scheme name="Project" version="173">
+  <JSON>
+    <option name="OBJECT_WRAPPING" value="0" />
+    <option name="ARRAY_WRAPPING" value="1" />
+  </JSON>
+  <DBN-PSQL>
+    <case-options enabled="true">
+      <option name="KEYWORD_CASE" value="lower" />
+      <option name="FUNCTION_CASE" value="lower" />
+      <option name="PARAMETER_CASE" value="lower" />
+      <option name="DATATYPE_CASE" value="lower" />
+      <option name="OBJECT_CASE" value="preserve" />
+    </case-options>
+    <formatting-settings enabled="false" />
+  </DBN-PSQL>
+  <DBN-SQL>
+    <case-options enabled="true">
+      <option name="KEYWORD_CASE" value="lower" />
+      <option name="FUNCTION_CASE" value="lower" />
+      <option name="PARAMETER_CASE" value="lower" />
+      <option name="DATATYPE_CASE" value="lower" />
+      <option name="OBJECT_CASE" value="preserve" />
+    </case-options>
+    <formatting-settings enabled="false">
+      <option name="STATEMENT_SPACING" value="one_line" />
+      <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
+      <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
+    </formatting-settings>
+  </DBN-SQL>
+  <codeStyleSettings language="JSON">
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="WRAP_ON_TYPING" value="0" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>

--- a/docs/profile.example.json
+++ b/docs/profile.example.json
@@ -3,26 +3,30 @@
   "alps": {
     "title": "ALPS example",
     "descriptor": [
-      {"id": "Index", "type": "semantic", "doc": {"value": "Index Page"}, "descriptor": [
+      {
+        "id": "Index", "type": "semantic", "doc": {"value": "Index Page"},
+        "descriptor": [
           {"href": "#start"}
         ]
       },
-      {"id": "About", "type": "semantic", "descriptor": [
+      {
+        "id": "About", "type": "semantic",
+        "descriptor": [
           {"href": "#backToBlog"}
         ]
       },
       {
-        "id": "Blog", "type": "semantic", "def": "https://schema.org/Blog", "descriptor": [
-          {"href": "#BlogPosting"},
-          {"href": "#blogPosting"},
+        "id": "Blog", "type": "semantic", "def": "https://schema.org/Blog",
+        "descriptor": [
+          {"href": "#BlogPosting"}, {"href": "#blogPosting"},
           {"href": "#post"},
           {"href": "#about"}
         ]
       },
-      {"id": "BlogPosting", "type": "semantic", "def": "https://schema.org/BlogPosting", "descriptor": [
-          {"href": "#id"},
-          {"href": "#articleBody"},
-          {"href": "#dateCreated"},
+      {
+        "id": "BlogPosting", "type": "semantic", "def": "https://schema.org/BlogPosting",
+        "descriptor": [
+          {"href": "#id"}, {"href": "#articleBody"}, {"href": "#dateCreated"},
           {"href": "#blog"}
         ]
       },
@@ -33,11 +37,14 @@
 
       {"id": "start", "type": "safe", "rt": "#Blog"},
       {"id": "backToBlog", "type": "safe", "rt": "#Blog"},
-      {"id": "blogPosting", "type": "safe", "rt": "#BlogPosting", "rel": "item", "descriptor": [
+      {
+        "id": "blogPosting", "type": "safe", "rt": "#BlogPosting", "rel": "item",
+        "descriptor": [
           {"href": "#id"}
         ]
       },
-      {"id": "post", "type": "unsafe", "def": "http://activitystrea.ms/specs/json/1.0/#post-verb", "rt": "#Blog",
+      {
+        "id": "post", "type": "unsafe", "def": "http://activitystrea.ms/specs/json/1.0/#post-verb", "rt": "#Blog",
         "descriptor": [
           {"href": "#articleBody"}
         ]


### PR DESCRIPTION
While there is no official style for the JSON format in ALPS, we are adding a coding standard set by this utility for the convenience of our users.

It's for IntelliJ users.

**How to install coding style:**

1. Download alps_json.xml from code_style/intellij folder. 
1. Choose alps_json.xml at  `Preference > Editor > Code Style > JSON > Import Schema 