### PR TITLE
Replace only extension

### DIFF
--- a/bin/asd
+++ b/bin/asd
@@ -62,7 +62,7 @@ try {
 $file = str_replace('.json', '.dot', $profile);
 file_put_contents($file, $dot);
 
-$svgFile = str_replace(['xml', 'json'], 'svg', $profile);
+$svgFile = str_replace(['.xml', '.json'], '.svg', $profile);
 $cmd = "dot -Tsvg {$file} -o {$svgFile}";
 passthru($cmd, $status);
 if ($status !== 0) {


### PR DESCRIPTION
When alps has `json` like a `path/to/json/profile.json` is given, svg is output to `path/to/svg/profile.svg`.