### PR TITLE
Support remote profile

### DIFF
--- a/tests/AlpsProfileTest.php
+++ b/tests/AlpsProfileTest.php
@@ -8,6 +8,10 @@ use Koriym\AppStateDiagram\Exception\AlpsFileNotReadableException;
 use Koriym\AppStateDiagram\Exception\DescriptorNotFoundException;
 use PHPUnit\Framework\TestCase;
 
+use function stream_wrapper_register;
+use function stream_wrapper_restore;
+use function stream_wrapper_unregister;
+
 class AlpsProfileTest extends TestCase
 {
     public function testProfile(): void
@@ -26,6 +30,15 @@ class AlpsProfileTest extends TestCase
     {
         $profile = new AlpsProfile('https://raw.githubusercontent.com/koriym/app-state-diagram/master/docs/blog/profile.json');
         $this->assertSame('start (safe)', (string) $profile->links['Index->Blog:start']);
+    }
+
+    public function testReadPhpInput(): void
+    {
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', FakeAlpsJsonInputStreamWrapper::class);
+        $profile = new AlpsProfile('php://input');
+        $this->assertSame('start (safe)', (string) $profile->links['Index->Blog:start']);
+        stream_wrapper_restore('php');
     }
 
     public function testFileNotReadable(): void

--- a/tests/AlpsProfileTest.php
+++ b/tests/AlpsProfileTest.php
@@ -10,17 +10,22 @@ use PHPUnit\Framework\TestCase;
 
 class AlpsProfileTest extends TestCase
 {
-    /** @var AlpsProfile */
-    protected $profile;
-
-    protected function setUp(): void
-    {
-        $this->profile = new AlpsProfile(__DIR__ . '/Fake/alps.json');
-    }
-
     public function testProfile(): void
     {
-        $this->assertSame('bar (safe)', (string) $this->profile->links['Foo->Bar:bar']);
+        $profile = new AlpsProfile(__DIR__ . '/Fake/alps.json');
+        $this->assertSame('bar (safe)', (string) $profile->links['Foo->Bar:bar']);
+    }
+
+    public function testIncludeExternalRemoteProfile(): void
+    {
+        $profile = new AlpsProfile(__DIR__ . '/Fake/alps.include_remote_profile.json');
+        $this->assertSame('start (safe)', (string) $profile->links['Index->Blog:start']);
+    }
+
+    public function testReadRemoteProfile(): void
+    {
+        $profile = new AlpsProfile('https://raw.githubusercontent.com/koriym/app-state-diagram/master/docs/blog/profile.json');
+        $this->assertSame('start (safe)', (string) $profile->links['Index->Blog:start']);
     }
 
     public function testFileNotReadable(): void

--- a/tests/Fake/FakeAlpsJsonInputStreamWrapper.php
+++ b/tests/Fake/FakeAlpsJsonInputStreamWrapper.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\AppStateDiagram;
+
+final class FakeAlpsJsonInputStreamWrapper
+{
+    /** @var string */
+    private $alpsFile;
+
+    /** @var int */
+    private $position;
+
+    public function __construct()
+    {
+        $this->alpsFile = (string) file_get_contents(__DIR__ . '/alps.include_remote_profile.json');
+        $this->position = 0;
+    }
+
+    public function stream_open(string $path): bool
+    {
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        $ret = substr($this->alpsFile, $this->position, $count);
+        $this->position += strlen($ret);
+        return $ret;
+    }
+
+    /**
+     * @return array<int|string, mixed>;
+     */
+    public function stream_stat(): array
+    {
+        return [];
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->position >= strlen($this->alpsFile);
+    }
+
+    /**
+     * @return array<int|string, mixed>;
+     */
+    public function url_stat(): array
+    {
+        return [];
+    }
+}

--- a/tests/Fake/alps.include_remote_profile.json
+++ b/tests/Fake/alps.include_remote_profile.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/alps-io/schemas/draft06/alps.json",
+  "alps": {
+    "descriptor": [
+      {
+        "id": "Index",
+        "descriptor": [
+          {"href": "https://raw.githubusercontent.com/koriym/app-state-diagram/master/docs/blog/profile.json#start"}
+        ],
+        "title": "Index"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
ASD can read a remote profile like the following.

```
asd https://raw.githubusercontent.com/koriym/app-state-diagram/master/docs/blog/profile.json
```

And, when profile has external remote profile like the following, it is read like a local external profile.

```json
{
  "$schema": "https://raw.githubusercontent.com/alps-io/schemas/draft06/alps.json",
  "alps": {
    "descriptor": [
      {
        "id": "Index",
        "descriptor": [
          {"href": "https://raw.githubusercontent.com/koriym/app-state-diagram/master/docs/blog/profile.json#start"}
        ],
        "title": "Index"
      }
    ]
  }
}
```

In addition, `php://input` is supported.