### PR TITLE
Override title of href in doc

### DIFF
--- a/src/DumpDocs.php
+++ b/src/DumpDocs.php
@@ -205,7 +205,12 @@ EOT;
             $id = substr($descriptor->href, (int) strpos($descriptor->href, '#') + 1);
             assert(isset($this->descriptors[$id]));
 
-            $descriptors[] = $this->descriptors[$id];
+            $original = clone $this->descriptors[$id];
+            if (isset($descriptor->title)) {
+                $original->title = (string) $descriptor->title;
+            }
+
+            $descriptors[] = $original;
         }
 
         usort($descriptors, static function (AbstractDescriptor $a, AbstractDescriptor $b): int {

--- a/tests/DumpDocsTest.php
+++ b/tests/DumpDocsTest.php
@@ -39,6 +39,7 @@ class DumpDocsTest extends TestCase
 
         $this->assertStringContainsString(/** @lang HTML */'<th>title</th>', $html);
         $this->assertStringContainsString(/** @lang HTML */'<td>baz-title</td>', $html);
+        $this->assertStringContainsString(/** @lang HTML */'<td>override foo-title</td>', $html);
     }
 
     public function testTagDoc(): void

--- a/tests/Fake/project/min/docs/semantic.bar.html
+++ b/tests/Fake/project/min/docs/semantic.bar.html
@@ -41,6 +41,11 @@
   <td>semantic</td>
   <td>baz-title</td>
 </tr>
+<tr>
+  <td><a href="semantic.foo.html">foo</a></td>
+  <td>semantic</td>
+  <td>override foo-title</td>
+</tr>
 </tbody>
 </table></li>
 </ul>

--- a/tests/Fake/project/min/profile.json
+++ b/tests/Fake/project/min/profile.json
@@ -4,7 +4,8 @@
     "descriptor": [
       {"id": "foo", "title": "foo-title"},
       {"id": "bar", "descriptor": [
-        {"id": "baz", "title": "baz-title"}
+        {"id": "baz", "title": "baz-title"},
+        {"href": "#foo", "title": "override foo-title"}
       ]}
     ]
   }


### PR DESCRIPTION
When give like the following profile, title of id in the `semantic.Foo.html` is described `Foo id`.

```xml
<descriptor id="id" />
<descriptor id="Foo">
    <descriptor href="#id" title="Foo id" />
</descriptor>
```