### PR TITLE
Support link element of descriptor

### DIFF
--- a/alps.xsd
+++ b/alps.xsd
@@ -15,7 +15,6 @@
         </xs:annotation>
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="version" minOccurs="0"/>
                 <xs:element ref="doc" minOccurs="0"/>
                 <xs:element ref="link" minOccurs="0"/>
                 <xs:element ref="title" minOccurs="0"/>
@@ -23,6 +22,11 @@
                 <xs:element ref="descriptor"/>
             </xs:choice>
         </xs:sequence>
+        <xs:attribute name="version" type="xs:string">
+            <xs:annotation>
+                <xs:documentation> Indicates the version of the ALPS specification used in the document. </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:element name="version" type="xs:string">
         <xs:annotation>
@@ -81,6 +85,7 @@
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="descriptor" type="descriptorType" minOccurs="0"/>
                 <xs:element name="doc" type="docType" minOccurs="0"/>
+                <xs:element name="link" type="linkType" minOccurs="0"/>
             </xs:choice>
         </xs:sequence>
         <!-- documented attribute -->
@@ -123,6 +128,7 @@
         <xs:attribute name="rel" type="xs:string"/>
         <xs:attribute name="href" type="xs:anyURI"/>
         <xs:attribute name="tag" type="xs:string"/>
+        <xs:attribute name="title" type="xs:string"/>
         <xs:anyAttribute/>
     </xs:complexType>
     <xs:complexType name="docType">

--- a/docs/blog/docs/semantic.BlogPosting.html
+++ b/docs/blog/docs/semantic.BlogPosting.html
@@ -29,6 +29,11 @@
 <li>type: semantic</li>
 <li>title: Blog post item</li>
 <li>def: <a href="https://schema.org/BlogPosting">https://schema.org/BlogPosting</a></li>
+<li>relations
+
+<ul>
+<li>rel: schema <a rel="schema" href="schema/BlogPosting.json">schema/BlogPosting.json</a> JsonSchema file</li>
+</ul></li>
 <li>descriptor
 <table>
 <thead>

--- a/docs/blog/docs/semantic.BlogPosting.html
+++ b/docs/blog/docs/semantic.BlogPosting.html
@@ -29,7 +29,7 @@
 <li>type: semantic</li>
 <li>title: Blog post item</li>
 <li>def: <a href="https://schema.org/BlogPosting">https://schema.org/BlogPosting</a></li>
-<li>relations
+<li>links
 
 <ul>
 <li>rel: schema <a rel="schema" href="schema/BlogPosting.json">schema/BlogPosting.json</a> JsonSchema file</li>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -44,7 +44,7 @@
 <li><a href="docs/semantic.id.html">id</a> (semantic)</li>
 <li><a href="docs/semantic.Index.html">Index</a> (semantic), Index Page</li>
 </ul></li>
-<li>Relations
+<li>Links
 
 <ul>
 <li>rel: issue <a rel="issue" href="https://github.com/koriym/app-state-diagram/issues">https://github.com/koriym/app-state-diagram/issues</a></li>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -47,7 +47,7 @@
 <li>Relations
 
 <ul>
-<li><a href="https://github.com/koriym/app-state-diagram/issues">issue</a></li>
+<li>rel: issue <a rel="issue" href="https://github.com/koriym/app-state-diagram/issues">https://github.com/koriym/app-state-diagram/issues</a></li>
 </ul></li>
 </ul>
 

--- a/docs/blog/profile.json
+++ b/docs/blog/profile.json
@@ -21,7 +21,7 @@
         {"href": "#goAbout"},
         {"href": "#doPost"}
       ]},
-      {"id": "BlogPosting", "type": "semantic", "title": "Blog post item", "def": "https://schema.org/BlogPosting", "descriptor": [
+      {"id": "BlogPosting", "type": "semantic", "title": "Blog post item", "def": "https://schema.org/BlogPosting", "link": {"rel": "schema", "href": "schema/BlogPosting.json", "title": "JsonSchema file"} ,"descriptor": [
         {"href": "#id"},
         {"href": "#articleBody"},
         {"href": "#dateCreated"},

--- a/docs/blog/schema/BlogPosting.json
+++ b/docs/blog/schema/BlogPosting.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "BlogPosting.json",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "articleBody": {
+      "type": "string"
+    },
+    "dateCreated": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "required": [
+    "id",
+    "articleBody",
+    "dateCreated"
+  ]
+}

--- a/docs/todomvc/index.html
+++ b/docs/todomvc/index.html
@@ -66,7 +66,7 @@
 <li>Relations
 
 <ul>
-<li><a href="https://github.com/tastejs/todomvc/blob/master/app-spec.md">help</a></li>
+<li>rel: help <a rel="help" href="https://github.com/tastejs/todomvc/blob/master/app-spec.md">https://github.com/tastejs/todomvc/blob/master/app-spec.md</a></li>
 </ul></li>
 </ul>
 

--- a/docs/todomvc/index.html
+++ b/docs/todomvc/index.html
@@ -63,7 +63,7 @@
 <li><a href="docs/semantic.todoItem.html">todoItem</a> (semantic)</li>
 <li><a href="docs/semantic.todoList.html">todoList</a> (semantic)</li>
 </ul></li>
-<li>Relations
+<li>Links
 
 <ul>
 <li>rel: help <a rel="help" href="https://github.com/tastejs/todomvc/blob/master/app-spec.md">https://github.com/tastejs/todomvc/blob/master/app-spec.md</a></li>

--- a/src/AbstractDescriptor.php
+++ b/src/AbstractDescriptor.php
@@ -44,6 +44,9 @@ abstract class AbstractDescriptor
     /** @var object */
     public $source;
 
+    /** @var LinkRelations */
+    public $linkRelations;
+
     public function __construct(object $descriptor, ?stdClass $parentDescriptor = null)
     {
         if (! isset($descriptor->id)) {
@@ -68,6 +71,9 @@ abstract class AbstractDescriptor
         if (isset($descriptor->rel)) {
             $this->rel = (string) $descriptor->rel;
         }
+
+        /** @psalm-suppress all */
+        $this->linkRelations = new LinkRelations($descriptor->link ?? null); // @phpstan-ignore-line
     }
 
     public function htmlLink(): string

--- a/src/DumpDocs.php
+++ b/src/DumpDocs.php
@@ -118,12 +118,13 @@ EOT;
         $description .= $this->getDescriptorProp('src', $descriptor);
         $description .= $this->getDescriptorProp('rel', $descriptor);
         $description .= $this->getTag($descriptor->tags);
+        $linkRelations = $this->getLinkRelations($descriptor->linkRelations);
         $titleHeader = $title ? sprintf('%s: Semantic Descriptor', $title) : 'Semantic Descriptor';
 
         return <<<EOT
 {$titleHeader}
 # {$descriptor->id}
-{$description}{$rt}{$descriptorSemantic}
+{$description}{$rt}{$linkRelations}{$descriptorSemantic}
 ---
 
 [home](../index.html) | [asd]($asd)
@@ -269,5 +270,14 @@ EOT;
 
 [home](../index.html) | [asd]({$asd}) | {$tag} 
 EOT;
+    }
+
+    private function getLinkRelations(LinkRelations $linkRelations): string
+    {
+        if ((string) $linkRelations === '') {
+            return '';
+        }
+
+        return ' * relations' . PHP_EOL . $linkRelations;
     }
 }

--- a/src/DumpDocs.php
+++ b/src/DumpDocs.php
@@ -278,6 +278,6 @@ EOT;
             return '';
         }
 
-        return ' * relations' . PHP_EOL . $linkRelations;
+        return ' * links' . PHP_EOL . $linkRelations;
     }
 }

--- a/src/IndexPage.php
+++ b/src/IndexPage.php
@@ -95,6 +95,6 @@ EOT;
             return '';
         }
 
-        return PHP_EOL . ' * Relations' . PHP_EOL . $linkRelations;
+        return PHP_EOL . ' * Links' . PHP_EOL . $linkRelations;
     }
 }

--- a/src/LinkRelation.php
+++ b/src/LinkRelation.php
@@ -10,6 +10,8 @@ use stdClass;
 use function json_encode;
 use function sprintf;
 
+use const PHP_EOL;
+
 final class LinkRelation
 {
     /** @var string */
@@ -17,6 +19,9 @@ final class LinkRelation
 
     /** @var string */
     public $rel;
+
+    /** @var string */
+    public $title;
 
     public function __construct(stdClass $link)
     {
@@ -30,13 +35,24 @@ final class LinkRelation
 
         /** @psalm-suppress MixedAssignment */
         $this->href = $link->href;
-
         /** @psalm-suppress MixedAssignment */
         $this->rel = $link->rel;
+        /** @psalm-suppress MixedAssignment */
+        $this->title = $link->title ?? '';
     }
 
     public function __toString(): string
     {
-        return sprintf('   * [%s](%s)', $this->rel, $this->href);
+        return sprintf('   * %s', $this->toLink());
+    }
+
+    private function toLink(): string
+    {
+        $str = sprintf('rel: %s <a rel="%s" href="%s">%s</a>', $this->rel, $this->rel, $this->href, $this->href);
+        if ($this->title !== '') {
+            $str .= " {$this->title}" . PHP_EOL;
+        }
+
+        return $str;
     }
 }

--- a/tests/DumpDocsTest.php
+++ b/tests/DumpDocsTest.php
@@ -51,4 +51,16 @@ class DumpDocsTest extends TestCase
         $this->assertFileExists(__DIR__ . '/Fake/docs/tag.a.html');
         $this->assertFileExists(__DIR__ . '/Fake/docs/tag.b.html');
     }
+
+    public function testRelations(): void
+    {
+        $alpsFile = __DIR__ . '/Fake/alps_has_multiple_link.json';
+        $profile = new Profile($alpsFile);
+        (new DumpDocs())($profile, $alpsFile);
+        $html = (string) file_get_contents(__DIR__ . '/Fake/docs/semantic.Item.html');
+
+        $this->assertStringContainsString(/** @lang HTML */'<li>relations', $html);
+        $this->assertStringContainsString(/** @lang HTML */'<li>rel: help <a rel="help" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a> API Help File</li>', $html);
+        $this->assertStringContainsString(/** @lang HTML */'<li>rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a></li>', $html);
+    }
 }

--- a/tests/DumpDocsTest.php
+++ b/tests/DumpDocsTest.php
@@ -59,7 +59,7 @@ class DumpDocsTest extends TestCase
         (new DumpDocs())($profile, $alpsFile);
         $html = (string) file_get_contents(__DIR__ . '/Fake/docs/semantic.Item.html');
 
-        $this->assertStringContainsString(/** @lang HTML */'<li>relations', $html);
+        $this->assertStringContainsString(/** @lang HTML */'<li>links', $html);
         $this->assertStringContainsString(/** @lang HTML */'<li>rel: help <a rel="help" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a> API Help File</li>', $html);
         $this->assertStringContainsString(/** @lang HTML */'<li>rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a></li>', $html);
     }

--- a/tests/Fake/alps_has_multiple_link.json
+++ b/tests/Fake/alps_has_multiple_link.json
@@ -12,9 +12,26 @@
       }
     ],
     "descriptor": [
+      {"id": "id"},
       {
-        "id": "id",
-        "tag": "tag1"
+        "id": "Item",
+        "tag": "tag1",
+        "link": [
+          {
+            "rel": "help",
+            "href": "https://github.com/koriym/app-state-diagram/",
+            "title": "API Help File"
+          },
+          {
+            "rel": "about",
+            "href": "https://github.com/koriym/app-state-diagram/"
+          }
+        ],
+        "descriptor": [
+          {
+            "href": "#id"
+          }
+        ]
       }
     ]
   }

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -22,7 +22,7 @@ class IndexPageTest extends TestCase
      */
     public function testLinkRelationsIsMissing(string $html): void
     {
-        $this->assertStringNotContainsString('Relations', $html);
+        $this->assertStringNotContainsString('Links', $html);
     }
 
     public function testTagString(): void

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -45,14 +45,14 @@ class IndexPageTest extends TestCase
     {
         $alpsFile = __DIR__ . '/Fake/alps_has_single_link.json';
         $html = (new IndexPage(new Profile($alpsFile)))->index;
-        $this->assertStringContainsString('<li><a href="https://github.com/koriym/app-state-diagram/">about</a></li>', $html);
+        $this->assertStringContainsString('<li>rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a></li>', $html);
     }
 
     public function testMultipleLinkRelationsString(): void
     {
         $alpsFile = __DIR__ . '/Fake/alps_has_multiple_link.json';
         $html = (new IndexPage(new Profile($alpsFile)))->index;
-        $this->assertStringContainsString('<li><a href="https://github.com/koriym/app-state-diagram/">about</a></li>', $html);
-        $this->assertStringContainsString('<li><a href="https://github.com/koriym/app-state-diagram/">repository</a></li>', $html);
+        $this->assertStringContainsString('<li>rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a></li>', $html);
+        $this->assertStringContainsString('<li>rel: repository <a rel="repository" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a></li>', $html);
     }
 }


### PR DESCRIPTION
Fix #71 

Here is an example.

![image](https://user-images.githubusercontent.com/17171732/121024783-80f36000-c7df-11eb-8b9b-3fa4f0528b84.png)

I did dump a table like a descriptor, but can not dump to clear 😓

![image (1)](https://user-images.githubusercontent.com/17171732/121026059-be0c2200-c7e0-11eb-9c88-b73ed1f729f8.png)

```
# Item
 * type: semantic
 * tag: [tag1](tag.tag1.html)
 * descriptor
| id | type | title |
|---|---|---|
| [id](semantic.id.html) | semantic |  |
 * links
|rel|title|
|---|---|
| [rel1](https://github.com/koriym/app-state-diagram/) |  |
```