### PR TITLE
Overwrite config with CLI options

### DIFF
--- a/bin/asd
+++ b/bin/asd
@@ -20,12 +20,12 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php
     }
 }
 
-$options = getopt('c:', ['config:']);
+$options = getopt('c:w::', ['config:', 'watch::', 'color::', 'and-tag::', 'or-tag::']);
 if ($argc === 1) {
     $options['c'] = getcwd();
 }
 try {
-    $config = isset($options['c']) ? ConfigFactory::fromFile($options['c'], $argc, $argv) : ConfigFactory::fromCommandLine($argc, $argv);
+    $config = isset($options['c']) ? ConfigFactory::fromFile($options['c'], $argc, $argv, $options) : ConfigFactory::fromCommandLine($argc, $argv, $options);
 } catch (DataFileNotFoundException $e) {
     printf('Config file not found: %s', $e->getMessage());
     exit(1);

--- a/bin/asd
+++ b/bin/asd
@@ -27,7 +27,7 @@ if ($argc === 1) {
 try {
     $config = isset($options['c']) ? ConfigFactory::fromFile($options['c'], $argc, $argv) : ConfigFactory::fromCommandLine($argc, $argv);
 } catch (DataFileNotFoundException $e) {
-    printf('Config gile not found: %s', $e->getMessage());
+    printf('Config file not found: %s', $e->getMessage());
     exit(1);
 } catch (AlpsFileNotReadableException $e) {
     printf('Profile file not found: %s', $e->getMessage());

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Koriym\AppStateDiagram;
 
 use Koriym\AppStateDiagram\Exception\AlpsFileNotReadableException;
-use SimpleXMLElement;
 
 use function is_file;
-use function property_exists;
 
 final class Config
 {
@@ -24,7 +22,7 @@ final class Config
     /** @var bool */
     public $hasTag;
 
-    public function __construct(string $profile, bool $watch, ?SimpleXMLElement $filter)
+    public function __construct(string $profile, bool $watch, ConfigFilter $filter)
     {
         if (! is_file($profile)) {
             throw new AlpsFileNotReadableException($profile);
@@ -32,12 +30,7 @@ final class Config
 
         $this->profile = $profile;
         $this->watch = $watch;
-        /** @var array<string> $and */
-        $and = $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? (array) $filter->and : [];
-        /** @var array<string> $or */
-        $or = $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? (array) $filter->or : [];
-        $color = $filter instanceof SimpleXMLElement && property_exists($filter, 'color') ? (string) $filter->color : '';
-        $this->filter = new ConfigFilter($and, $or, $color);
-        $this->hasTag = $and || $or;
+        $this->filter = $filter;
+        $this->hasTag = $filter->and || $filter->or;
     }
 }

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -9,19 +9,19 @@ use SimpleXMLElement;
 
 use function assert;
 use function dirname;
-use function explode;
-use function in_array;
 use function is_dir;
 use function is_file;
 use function property_exists;
 use function realpath;
 use function sprintf;
-use function strpos;
 
 final class ConfigFactory
 {
-    /** @param array<string> $argv */
-    public static function fromFile(string $configFile, int $argc = 1, array $argv = ['']): Config
+    /**
+     * @param array<string>        $argv
+     * @param array<string, mixed> $options
+     */
+    public static function fromFile(string $configFile, int $argc = 1, array $argv = [''], array $options = []): Config
     {
         $xml = (new XmlConfigLoad('asd.xml'))($configFile, dirname(__DIR__) . '/docs/asd.xsd');
         assert(property_exists($xml, 'alpsFile'));
@@ -31,84 +31,29 @@ final class ConfigFactory
 
         $maybePath = (string) realpath($argv[$argc - 1]);
         $profile = is_file($maybePath) ? $maybePath : sprintf('%s/%s', $dir, (string) $xml->alpsFile);
-        $watch = in_array('--watch', $argv, true) || (string) $xml->watch === 'true';
         /** @var ?SimpleXMLElement $filter */
         $filter = property_exists($xml, 'filter') ? $xml->filter : null;
-        $and = self::parseAndTag($argv, $filter);
-        $or = self::parseOrTag($argv, $filter);
-        $color = self::parseColor($argv, $filter);
+        $option = new Option($options, $filter);
 
         return new Config(
             $profile,
-            $watch,
-            new ConfigFilter($and, $or, $color)
+            $option->watch,
+            new ConfigFilter($option->and, $option->or, $option->color)
         );
     }
 
-    /** @param array<string> $argv */
-    public static function fromCommandLine(int $argc, array $argv): Config
+    /**
+     * @param array<string>        $argv
+     * @param array<string, mixed> $options
+     */
+    public static function fromCommandLine(int $argc, array $argv, array $options): Config
     {
-        $watch = in_array('--watch', $argv, true);
-        $and = self::parseAndTag($argv, null);
-        $or = self::parseOrTag($argv, null);
-        $color = self::parseColor($argv, null);
+        $option = new Option($options, null);
 
         return new Config(
             (string) realpath($argv[$argc - 1]),
-            $watch,
-            new ConfigFilter($and, $or, $color)
+            $option->watch,
+            new ConfigFilter($option->and, $option->or, $option->color)
         );
-    }
-
-    /**
-     * @param array<string> $options
-     *
-     * @return array<string>
-     */
-    private static function parseAndTag(array $options, ?SimpleXMLElement $filter): array
-    {
-        foreach ($options as $option) {
-            if (strpos($option, '--and-tag=') === 0) {
-                [, $value] = explode('=', $option);
-
-                return explode(',', $value);
-            }
-        }
-
-        return $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? (array) $filter->and : [];
-    }
-
-    /**
-     * @param array<string> $options
-     *
-     * @return array<string>
-     */
-    private static function parseOrTag(array $options, ?SimpleXMLElement $filter): array
-    {
-        foreach ($options as $option) {
-            if (strpos($option, '--or-tag=') === 0) {
-                [, $value] = explode('=', $option);
-
-                return explode(',', $value);
-            }
-        }
-
-        return $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? (array) $filter->or : [];
-    }
-
-    /**
-     * @param array<string> $options
-     */
-    private static function parseColor(array $options, ?SimpleXMLElement $filter): string
-    {
-        foreach ($options as $option) {
-            if (strpos($option, '--color=') === 0) {
-                [, $value] = explode('=', $option);
-
-                return $value;
-            }
-        }
-
-        return $filter instanceof SimpleXMLElement && property_exists($filter, 'color') ? (string) $filter->color : '';
     }
 }

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -9,11 +9,14 @@ use SimpleXMLElement;
 
 use function assert;
 use function dirname;
+use function explode;
+use function in_array;
 use function is_dir;
 use function is_file;
 use function property_exists;
 use function realpath;
 use function sprintf;
+use function strpos;
 
 final class ConfigFactory
 {
@@ -28,23 +31,84 @@ final class ConfigFactory
 
         $maybePath = (string) realpath($argv[$argc - 1]);
         $profile = is_file($maybePath) ? $maybePath : sprintf('%s/%s', $dir, (string) $xml->alpsFile);
+        $watch = in_array('--watch', $argv, true) || (string) $xml->watch === 'true';
         /** @var ?SimpleXMLElement $filter */
-        $filter = property_exists($xml, 'filter') ?  $xml->filter : null;
+        $filter = property_exists($xml, 'filter') ? $xml->filter : null;
+        $and = self::parseAndTag($argv, $filter);
+        $or = self::parseOrTag($argv, $filter);
+        $color = self::parseColor($argv, $filter);
 
         return new Config(
             $profile,
-            (string) $xml->watch === 'true',
-            $filter
+            $watch,
+            new ConfigFilter($and, $or, $color)
         );
     }
 
     /** @param array<string> $argv */
     public static function fromCommandLine(int $argc, array $argv): Config
     {
+        $watch = in_array('--watch', $argv, true);
+        $and = self::parseAndTag($argv, null);
+        $or = self::parseOrTag($argv, null);
+        $color = self::parseColor($argv, null);
+
         return new Config(
             (string) realpath($argv[$argc - 1]),
-            false,
-            null
+            $watch,
+            new ConfigFilter($and, $or, $color)
         );
+    }
+
+    /**
+     * @param array<string> $options
+     *
+     * @return array<string>
+     */
+    private static function parseAndTag(array $options, ?SimpleXMLElement $filter): array
+    {
+        foreach ($options as $option) {
+            if (strpos($option, '--and-tag=') === 0) {
+                [, $value] = explode('=', $option);
+
+                return explode(',', $value);
+            }
+        }
+
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? (array) $filter->and : [];
+    }
+
+    /**
+     * @param array<string> $options
+     *
+     * @return array<string>
+     */
+    private static function parseOrTag(array $options, ?SimpleXMLElement $filter): array
+    {
+        foreach ($options as $option) {
+            if (strpos($option, '--or-tag=') === 0) {
+                [, $value] = explode('=', $option);
+
+                return explode(',', $value);
+            }
+        }
+
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? (array) $filter->or : [];
+    }
+
+    /**
+     * @param array<string> $options
+     */
+    private static function parseColor(array $options, ?SimpleXMLElement $filter): string
+    {
+        foreach ($options as $option) {
+            if (strpos($option, '--color=') === 0) {
+                [, $value] = explode('=', $option);
+
+                return $value;
+            }
+        }
+
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'color') ? (string) $filter->color : '';
     }
 }

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -18,8 +18,8 @@ use function sprintf;
 final class ConfigFactory
 {
     /**
-     * @param array<string>        $argv
-     * @param array<string, mixed> $options
+     * @param array<string>              $argv
+     * @param array<string, string|bool> $options
      */
     public static function fromFile(string $configFile, int $argc = 1, array $argv = [''], array $options = []): Config
     {
@@ -43,8 +43,8 @@ final class ConfigFactory
     }
 
     /**
-     * @param array<string>        $argv
-     * @param array<string, mixed> $options
+     * @param array<string>              $argv
+     * @param array<string, string|bool> $options
      */
     public static function fromCommandLine(int $argc, array $argv, array $options): Config
     {

--- a/src/Option.php
+++ b/src/Option.php
@@ -10,6 +10,7 @@ use function explode;
 use function is_string;
 use function property_exists;
 
+/** @psalm-immutable */
 final class Option
 {
     /**
@@ -37,7 +38,7 @@ final class Option
     public $color;
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, string|bool> $options
      */
     public function __construct(array $options, ?SimpleXMLElement $filter)
     {
@@ -48,7 +49,7 @@ final class Option
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, string|bool> $options
      *
      * @return array<string>
      */
@@ -62,7 +63,7 @@ final class Option
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, string|bool> $options
      *
      * @return array<string>
      */
@@ -76,7 +77,7 @@ final class Option
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param array<string, string|bool> $options
      */
     private function parseColor(array $options, ?SimpleXMLElement $filter): string
     {

--- a/src/Option.php
+++ b/src/Option.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\AppStateDiagram;
+
+use SimpleXMLElement;
+
+use function explode;
+use function is_string;
+use function property_exists;
+
+final class Option
+{
+    /**
+     * @var bool
+     * @readonly
+     */
+    public $watch;
+
+    /**
+     * @var array<string>
+     * @readonly
+     */
+    public $and;
+
+    /**
+     * @var array<string>
+     * @readonly
+     */
+    public $or;
+
+    /**
+     * @var string
+     * @readonly
+     */
+    public $color;
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(array $options, ?SimpleXMLElement $filter)
+    {
+        $this->watch = isset($options['w']) || isset($options['watch']);
+        $this->and = $this->parseAndTag($options, $filter);
+        $this->or = $this->parseOrTag($options, $filter);
+        $this->color = $this->parseColor($options, $filter);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string>
+     */
+    private function parseAndTag(array $options, ?SimpleXMLElement $filter): array
+    {
+        if (isset($options['and-tag']) && is_string($options['and-tag'])) {
+            return explode(',', $options['and-tag']);
+        }
+
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? (array) $filter->and : [];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string>
+     */
+    private function parseOrTag(array $options, ?SimpleXMLElement $filter): array
+    {
+        if (isset($options['or-tag']) && is_string($options['or-tag'])) {
+            return explode(',', $options['or-tag']);
+        }
+
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? (array) $filter->or : [];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function parseColor(array $options, ?SimpleXMLElement $filter): string
+    {
+        if (isset($options['color']) && is_string($options['color'])) {
+            return $options['color'];
+        }
+
+        return $filter instanceof SimpleXMLElement && property_exists($filter, 'color') ? (string) $filter->color : '';
+    }
+}

--- a/tests/ConfigLoadTest.php
+++ b/tests/ConfigLoadTest.php
@@ -6,6 +6,7 @@ namespace Koriym\AppStateDiagram;
 
 use PHPUnit\Framework\TestCase;
 
+use function count;
 use function file_exists;
 
 class ConfigLoadTest extends TestCase
@@ -18,5 +19,46 @@ class ConfigLoadTest extends TestCase
         $this->assertFalse($config->watch);
         $this->assertSame(['tag1', 'tag2'], $config->filter->and);
         $this->assertSame(['tag3'], $config->filter->or);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function testOverwriteConfig(): array
+    {
+        $argv = [
+            '--watch',
+            '--and-tag=a,b',
+            '--or-tag=c,d',
+            '--color=red',
+            '-c',
+            __DIR__ . '/Fake/config',
+            __DIR__ . '/Fake/alps.json',
+        ];
+        $config = ConfigFactory::fromFile(__DIR__ . '/Fake/config', count($argv), $argv);
+        $this->assertSame(__DIR__ . '/Fake/alps.json', $config->profile);
+        $this->assertTrue($config->watch);
+        $this->assertTrue($config->hasTag);
+        $this->assertSame(['a', 'b'], $config->filter->and);
+        $this->assertSame(['c', 'd'], $config->filter->or);
+        $this->assertSame('red', $config->filter->color);
+
+        return $argv;
+    }
+
+    /**
+     * @param list<string> $argv
+     *
+     * @depends testOverwriteConfig
+     */
+    public function testFromCommandLine(array $argv): void
+    {
+        $config = ConfigFactory::fromCommandLine(count($argv), $argv);
+        $this->assertSame(__DIR__ . '/Fake/alps.json', $config->profile);
+        $this->assertTrue($config->watch);
+        $this->assertTrue($config->hasTag);
+        $this->assertSame(['a', 'b'], $config->filter->and);
+        $this->assertSame(['c', 'd'], $config->filter->or);
+        $this->assertSame('red', $config->filter->color);
     }
 }

--- a/tests/ConfigLoadTest.php
+++ b/tests/ConfigLoadTest.php
@@ -6,7 +6,6 @@ namespace Koriym\AppStateDiagram;
 
 use PHPUnit\Framework\TestCase;
 
-use function count;
 use function file_exists;
 
 class ConfigLoadTest extends TestCase
@@ -22,20 +21,18 @@ class ConfigLoadTest extends TestCase
     }
 
     /**
-     * @return list<string>
+     * @return array<string, mixed>
      */
     public function testOverwriteConfig(): array
     {
-        $argv = [
-            '--watch',
-            '--and-tag=a,b',
-            '--or-tag=c,d',
-            '--color=red',
-            '-c',
-            __DIR__ . '/Fake/config',
-            __DIR__ . '/Fake/alps.json',
+        $options = [
+            'watch' => true,
+            'and-tag' => 'a,b',
+            'or-tag' => 'c,d',
+            'color' => 'red',
+            '-c' => __DIR__ . '/Fake/config',
         ];
-        $config = ConfigFactory::fromFile(__DIR__ . '/Fake/config', count($argv), $argv);
+        $config = ConfigFactory::fromFile(__DIR__ . '/Fake/config', 1, [__DIR__ . '/Fake/alps.json'], $options);
         $this->assertSame(__DIR__ . '/Fake/alps.json', $config->profile);
         $this->assertTrue($config->watch);
         $this->assertTrue($config->hasTag);
@@ -43,17 +40,17 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
 
-        return $argv;
+        return $options;
     }
 
     /**
-     * @param list<string> $argv
+     * @param array<string, mixed> $options
      *
      * @depends testOverwriteConfig
      */
-    public function testFromCommandLine(array $argv): void
+    public function testFromCommandLine(array $options): void
     {
-        $config = ConfigFactory::fromCommandLine(count($argv), $argv);
+        $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], $options);
         $this->assertSame(__DIR__ . '/Fake/alps.json', $config->profile);
         $this->assertTrue($config->watch);
         $this->assertTrue($config->hasTag);


### PR DESCRIPTION
Add Option class to parse CLI options & overwrite `watch`, `and`, `or`, and `color` .

