### PR TITLE
label console option support

### DIFF
--- a/bin/asd
+++ b/bin/asd
@@ -8,9 +8,7 @@ use Koriym\AppStateDiagram\DrawDiagram;
 use Koriym\AppStateDiagram\DumpDocs;
 use Koriym\AppStateDiagram\Exception\AlpsFileNotReadableException;
 use Koriym\AppStateDiagram\IndexPage;
-use Koriym\AppStateDiagram\LabelName;
 use Koriym\AppStateDiagram\LabelNameFactory;
-use Koriym\AppStateDiagram\LabelNameTitle;
 use Koriym\AppStateDiagram\Profile;
 use Koriym\AppStateDiagram\TaggedProfile;
 use Koriym\DataFile\Exception\DataFileNotFoundException;
@@ -23,7 +21,7 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php
     }
 }
 
-$options = getopt('c:w::', ['config:', 'watch::', 'color::', 'and-tag::', 'or-tag::']);
+$options = getopt('c:w::l::', ['config:', 'watch::', 'color::', 'and-tag::', 'or-tag::', 'label::']);
 if ($argc === 1) {
     $options['c'] = getcwd();
 }

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -25,19 +25,18 @@ final class ConfigFactory
     {
         $xml = (new XmlConfigLoad('asd.xml'))($configFile, dirname(__DIR__) . '/docs/asd.xsd');
         assert(property_exists($xml, 'watch'));
-        $label = property_exists($xml, 'label')  ? (string) $xml->label : 'id';
         $dir = is_dir($configFile) ? $configFile : dirname($configFile);
 
         $maybePath = (string) realpath($argv[$argc - 1]);
         $profile = is_file($maybePath) && $configFile !== $maybePath ? $maybePath : sprintf('%s/%s', $dir, (string) $xml->alpsFile);
         /** @var ?SimpleXMLElement $filter */
         $filter = property_exists($xml, 'filter') ? $xml->filter : null;
-        $option = new Option($options, $filter);
+        $option = new Option($options, $filter, property_exists($xml, 'label') ? (string) $xml->label : null);
 
         return new Config(
             $profile,
             $option->watch,
-            $label,
+            $option->label,
             new ConfigFilter($option->and, $option->or, $option->color)
         );
     }
@@ -48,12 +47,12 @@ final class ConfigFactory
      */
     public static function fromCommandLine(int $argc, array $argv, array $options): Config
     {
-        $option = new Option($options, null);
+        $option = new Option($options, null, null);
 
         return new Config(
             (string) realpath($argv[$argc - 1]),
             $option->watch,
-            'id', // @todo Change option
+            $option->label,
             new ConfigFilter($option->and, $option->or, $option->color)
         );
     }

--- a/src/Exception/InvalidLabelOptionException.php
+++ b/src/Exception/InvalidLabelOptionException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\AppStateDiagram\Exception;
+
+use RuntimeException;
+
+class InvalidLabelOptionException extends RuntimeException
+{
+}

--- a/src/Option.php
+++ b/src/Option.php
@@ -7,12 +7,19 @@ namespace Koriym\AppStateDiagram;
 use SimpleXMLElement;
 
 use function explode;
+use function in_array;
 use function is_string;
 use function property_exists;
 
 /** @psalm-immutable */
 final class Option
 {
+    private const SUPPORTED_LABELS = [
+        'id',
+        'title',
+        'both',
+    ];
+
     /** @var bool */
     public $watch;
 
@@ -25,15 +32,19 @@ final class Option
     /** @var string */
     public $color;
 
+    /** @var string */
+    public $label;
+
     /**
      * @param array<string, string|bool> $options
      */
-    public function __construct(array $options, ?SimpleXMLElement $filter)
+    public function __construct(array $options, ?SimpleXMLElement $filter, ?string $label)
     {
         $this->watch = isset($options['w']) || isset($options['watch']);
         $this->and = $this->parseAndTag($options, $filter);
         $this->or = $this->parseOrTag($options, $filter);
         $this->color = $this->parseColor($options, $filter);
+        $this->label = $this->parseLabel($options, $label);
     }
 
     /**
@@ -78,5 +89,21 @@ final class Option
         }
 
         return $filter instanceof SimpleXMLElement && property_exists($filter, 'color') ? (string) $filter->color : '';
+    }
+
+    /** @param array<string, string|bool> $options */
+    private function parseLabel(array $options, ?string $label): string
+    {
+        if (! isset($options['label']) && ! isset($options['l'])) {
+            return $label ?? 'id';
+        }
+
+        $label = (string) ($options['label'] ?? $options['l']);
+
+        if (! in_array($label, self::SUPPORTED_LABELS, true)) {
+            return 'id';
+        }
+
+        return $label;
     }
 }

--- a/src/Option.php
+++ b/src/Option.php
@@ -47,6 +47,8 @@ final class Option
             return explode(',', $options['and-tag']);
         }
 
+        /** @var array<string> */ // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat
+
         return $filter instanceof SimpleXMLElement && property_exists($filter, 'and') ? (array) $filter->and : [];
     }
 
@@ -60,6 +62,8 @@ final class Option
         if (isset($options['or-tag']) && is_string($options['or-tag'])) {
             return explode(',', $options['or-tag']);
         }
+
+        /** @var array<string> */ // phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.InvalidFormat
 
         return $filter instanceof SimpleXMLElement && property_exists($filter, 'or') ? (array) $filter->or : [];
     }

--- a/src/Option.php
+++ b/src/Option.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\AppStateDiagram;
 
+use Koriym\AppStateDiagram\Exception\InvalidLabelOptionException;
 use SimpleXMLElement;
 
 use function explode;
@@ -101,7 +102,7 @@ final class Option
         $label = (string) ($options['label'] ?? $options['l']);
 
         if (! in_array($label, self::SUPPORTED_LABELS, true)) {
-            return 'id';
+            throw new InvalidLabelOptionException("{$label} is not supported. Supported values: [id|title|both].");
         }
 
         return $label;

--- a/tests/ConfigLoadTest.php
+++ b/tests/ConfigLoadTest.php
@@ -30,6 +30,7 @@ class ConfigLoadTest extends TestCase
             'and-tag' => 'a,b',
             'or-tag' => 'c,d',
             'color' => 'red',
+            'label' => 'title',
             '-c' => __DIR__ . '/Fake/config',
         ];
         $config = ConfigFactory::fromFile(__DIR__ . '/Fake/config', 1, [__DIR__ . '/Fake/alps.json'], $options);
@@ -39,6 +40,7 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['a', 'b'], $config->filter->and);
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
+        $this->assertSame('title', $config->label);
 
         return $options;
     }
@@ -57,5 +59,20 @@ class ConfigLoadTest extends TestCase
         $this->assertSame(['a', 'b'], $config->filter->and);
         $this->assertSame(['c', 'd'], $config->filter->or);
         $this->assertSame('red', $config->filter->color);
+        $this->assertSame('title', $config->label);
+    }
+
+    public function testInvalidLabelOptions(): void
+    {
+        $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], ['label' => 'test']);
+        $this->assertSame('id', $config->label);
+        $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], ['l' => 'test']);
+        $this->assertSame('id', $config->label);
+    }
+
+    public function testMultipleLabelOptions(): void
+    {
+        $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], ['label' => 'both', 'l' => 'title']);
+        $this->assertSame('both', $config->label);
     }
 }

--- a/tests/ConfigLoadTest.php
+++ b/tests/ConfigLoadTest.php
@@ -62,14 +62,6 @@ class ConfigLoadTest extends TestCase
         $this->assertSame('title', $config->label);
     }
 
-    public function testInvalidLabelOptions(): void
-    {
-        $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], ['label' => 'test']);
-        $this->assertSame('id', $config->label);
-        $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], ['l' => 'test']);
-        $this->assertSame('id', $config->label);
-    }
-
     public function testMultipleLabelOptions(): void
     {
         $config = ConfigFactory::fromCommandLine(1, [__DIR__ . '/Fake/alps.json'], ['label' => 'both', 'l' => 'title']);

--- a/tests/ErrorTest.php
+++ b/tests/ErrorTest.php
@@ -7,6 +7,7 @@ namespace Koriym\AppStateDiagram;
 use Koriym\AppStateDiagram\Exception\DescriptorIsNotArrayException;
 use Koriym\AppStateDiagram\Exception\DescriptorNotFoundException;
 use Koriym\AppStateDiagram\Exception\InvalidDescriptorException;
+use Koriym\AppStateDiagram\Exception\InvalidLabelOptionException;
 use Koriym\AppStateDiagram\Exception\RtMissingException;
 use PHPUnit\Framework\TestCase;
 use Seld\JsonLint\ParsingException;
@@ -48,5 +49,11 @@ class ErrorTest extends TestCase
     {
         $this->expectException(InvalidDescriptorException::class);
         (new DrawDiagram(new LabelName()))(new Profile(__DIR__ . '/Fake/invalid_null.json', new LabelName()));
+    }
+
+    public function testInvalidLabelOptionException(): void
+    {
+        $this->expectException(InvalidLabelOptionException::class);
+        new Option(['label' => '1', 'l' => '2'], null, null);
     }
 }


### PR DESCRIPTION
Fix #77 

When invalid label option was given, throw the `InvalidLabeOptionException` like a validation with XSD.