### PR TITLE
Fix markdown mode link relation href

### DIFF
--- a/bin/asd
+++ b/bin/asd
@@ -71,7 +71,6 @@ if ($status !== 0) {
     echo 'Warning: Graphviz error. https://graphviz.org/download/' . PHP_EOL;
 }
 
-$ext = 'html';
 $index = new IndexPage($profile, $config->outputMode);
 file_put_contents($index->file, $index->content);
 echo "ASD generated. {$index->file}" . PHP_EOL;

--- a/tests/Fake/alps_has_single_link.json
+++ b/tests/Fake/alps_has_single_link.json
@@ -2,7 +2,7 @@
   "$schema": "https://alps-io.github.io/schemas/alps.json",
   "alps": {
     "link": {
-      "href": "https://github.com/koriym/app-state-diagram/",
+      "href": "https://github.com/koriym/app-state-diagram/index.html",
       "rel": "about"
     },
     "descriptor": [

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -60,7 +60,14 @@ class IndexPageTest extends TestCase
     {
         $alpsFile = __DIR__ . '/Fake/alps_has_single_link.json';
         $html = (new IndexPage(new Profile($alpsFile, new LabelName())))->content;
-        $this->assertStringContainsString('<li>rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/">https://github.com/koriym/app-state-diagram/</a></li>', $html);
+        $this->assertStringContainsString('<li>rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/index.html">https://github.com/koriym/app-state-diagram/index.html</a></li>', $html);
+    }
+
+    public function testLinkRelationsStringMarkdownMode(): void
+    {
+        $alpsFile = __DIR__ . '/Fake/alps_has_single_link.json';
+        $md = (new IndexPage(new Profile($alpsFile, new LabelName()), DumpDocs::MODE_MARKDOWN))->content;
+        $this->assertStringContainsString('* rel: about <a rel="about" href="https://github.com/koriym/app-state-diagram/index.html">https://github.com/koriym/app-state-diagram/index.html</a>', $md);
     }
 
     public function testMultipleLinkRelationsString(): void


### PR DESCRIPTION
When markdown mode, `href` that includes `.html` of link relation will be replaced by `.md`.