### PR TITLE
Bump Node to 16.x

### DIFF
--- a/docker/app-state-diagram/Dockerfile
+++ b/docker/app-state-diagram/Dockerfile
@@ -5,8 +5,8 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN apt-get update \
  && apt-get -y --no-install-recommends install zip unzip \
  && apt-get -y --no-install-recommends install graphviz \
- && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
- && apt-get -y --no-install-recommends install nodejs npm \
+ && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+ && apt-get -y --no-install-recommends install nodejs \
  && rm -rf /var/lib/apt/lists/*
 
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer global require koriym/app-state-diagram \

--- a/docker/app-state-diagram/build.sh
+++ b/docker/app-state-diagram/build.sh
@@ -2,5 +2,5 @@
 
 cd "$(dirname "$0")"/.. || exit
 
-docker build -t app-state-diagram:latest -f app-state-diagram/Dockerfile app-state-diagram
+docker build -t ghcr.io/koriym/app-state-diagram:latest -f app-state-diagram/Dockerfile app-state-diagram
 # docker scan app-state-diagram:latest


### PR DESCRIPTION
- 16.x is current LTS
- installation instructions is from [here](https://github.com/nodesource/distributions#installation-instructions)