### PR TITLE
Add shareable URL state controls

### DIFF
--- a/docs/js/diagramAdapters.js
+++ b/docs/js/diagramAdapters.js
@@ -406,6 +406,17 @@ function scrollToDescriptor(id) {
     }
 }
 
+function setDescriptorHash(id) {
+    if (!id) return;
+    if (window.updateDiagramHash) {
+        window.updateDiagramHash(id);
+        return;
+    }
+    const url = new URL(window.location.href);
+    url.hash = '#' + encodeURIComponent(id);
+    window.history.replaceState(null, '', url.toString());
+}
+
 // Listen for messages from parent (for Preview mode scroll)
 window.addEventListener('message', function(event) {
     if (event.data && event.data.type === 'scrollToDescriptor') {
@@ -436,6 +447,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (href && href.startsWith('#')) {
                 const id = href.substring(1);
                 console.log('Extracted ID:', id);
+                setDescriptorHash(id);
 
                 if (window.parent !== window) {
                     // In iframe (editor mode): Send message to parent window
@@ -462,8 +474,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 href = href.substring(1);
             }
             const id = href.substring(1);
+            const currentRow = this.closest('tr');
+            const targetRow = document.getElementById('descriptor-' + id);
+            const hasDescriptorTarget = Boolean(targetRow);
+            if (hasDescriptorTarget) setDescriptorHash(id);
 
-            if (window.parent !== window) {
+            if (window.parent !== window && hasDescriptorTarget) {
                 // In iframe (editor mode): Send message to parent to jump to editor line
                 window.parent.postMessage({
                     type: 'jumpToId',
@@ -483,8 +499,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             // Check if this is a link to a different row (rt/Contained) or self (ID column)
-            const currentRow = this.closest('tr');
-            const targetRow = document.getElementById('descriptor-' + id);
 
             // Only scroll and highlight if linking to a different row
             if (targetRow && targetRow !== currentRow) {
@@ -646,12 +660,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 e.stopPropagation();
                 const id = href.substring(1);
                 console.log('Document click - extracted ID:', id);
+                if (!document.getElementById('descriptor-' + id)) return;
+                setDescriptorHash(id);
                 
                 if (window.parent !== window) {
                     window.parent.postMessage({
                         type: 'jumpToId',
                         id: id
                     }, '*');
+                } else {
+                    scrollToDescriptor(id);
                 }
             }
         }
@@ -691,6 +709,93 @@ ${linksHtml}
 
 // Tag filtering - using same logic as production ASD
 const tagDescriptorMap = ${escapeJsonForScript(tagDescriptorMap)};
+let isApplyingUrlState = false;
+let hasExplicitSizeMode = false;
+let currentDescriptorHash = '';
+
+const getTagsFromValues = (values) => {
+    return values
+        .flatMap(value => String(value).split(','))
+        .map(tag => tag.trim())
+        .filter(tag => tag && Object.prototype.hasOwnProperty.call(tagDescriptorMap, tag));
+};
+
+const getCurrentHash = () => {
+    return window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : '';
+};
+
+const getCurrentLabelMode = () => {
+    return document.querySelector('input[name="labelMode"]:checked')?.value || 'id';
+};
+
+const getCurrentSizeMode = () => {
+    return document.querySelector('input[name="sizeMode"]:checked')?.value || 'original';
+};
+
+const getSelectedTags = () => {
+    return Array.from(document.querySelectorAll('.tag-trigger-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.getAttribute('data-tag'))
+        .filter(Boolean);
+};
+
+const readUrlState = () => {
+    const params = new URLSearchParams(window.location.search);
+    const label = params.get('label') === 'title' ? 'title' : 'id';
+    const rawSize = params.get('size');
+    const size = rawSize === 'fit' || rawSize === 'original' ? rawSize : '';
+    return {
+        tag: getTagsFromValues(params.getAll('tag')),
+        label,
+        size,
+        hash: getCurrentHash()
+    };
+};
+
+const collectUrlState = () => {
+    return {
+        tag: getSelectedTags(),
+        label: getCurrentLabelMode(),
+        size: getCurrentSizeMode(),
+        hash: currentDescriptorHash || getCurrentHash()
+    };
+};
+
+const replaceUrlState = (state) => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tag');
+    if (state.tag.length > 0) {
+        url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.label === 'title') {
+        url.searchParams.set('label', 'title');
+    } else {
+        url.searchParams.delete('label');
+    }
+    if (state.size === 'fit' || state.size === 'original') {
+        url.searchParams.set('size', state.size);
+    } else {
+        url.searchParams.delete('size');
+    }
+    url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+    window.history.replaceState(null, '', url.toString());
+};
+
+const publishUrlState = () => {
+    if (isApplyingUrlState) return;
+    hasExplicitSizeMode = true;
+    const state = collectUrlState();
+    if (window.parent !== window) {
+        window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
+    } else {
+        replaceUrlState(state);
+    }
+};
+
+window.updateDiagramHash = (id) => {
+    currentDescriptorHash = id || '';
+    publishUrlState();
+};
 
 // Changes color of SVG elements by title (matching production ASD)
 const changeColorByTitle = (titleOrClass, newNodeColor, newEdgeColor, highlight = false) => {
@@ -736,13 +841,21 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', function() {
-            const tag = this.getAttribute('data-tag');
-            this.checked ?
-                document.dispatchEvent(new CustomEvent('tagon-' + tag)) :
-                document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+            applySelectedTagsToDiagram();
+            publishUrlState();
         });
     });
 };
+
+function applySelectedTagsToDiagram() {
+    const selectedTags = new Set(getSelectedTags());
+    Object.keys(tagDescriptorMap).forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+    });
+    selectedTags.forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagon-' + tag));
+    });
+}
 
 // Tag colors (cycle through for multiple tags)
 const tagColors = ['LightGreen', 'SkyBlue', 'LightCoral', 'LightSalmon', 'Khaki', 'Plum', 'Wheat'];
@@ -844,6 +957,15 @@ async function regenerateSvg(labelMode) {
         const vizInstance = new Viz();
         const svgString = await vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
+        applySelectedTagsToDiagram();
+        if (hasExplicitSizeMode) {
+            applySizeMode(getCurrentSizeMode());
+        } else {
+            autoSelectSizeMode();
+        }
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
         console.log('SVG regenerated with labelMode:', labelMode);
     } catch (error) {
         console.error('Error regenerating SVG:', error);
@@ -853,26 +975,35 @@ async function regenerateSvg(labelMode) {
 
 document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        regenerateSvg(this.value);
+        regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
 
 // Size mode toggle (Original / Fit to width)
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        const svgContainer = document.getElementById('svg-container');
-        if (this.value === 'fit') {
-            svgContainer.classList.add('fit-width');
-        } else {
-            svgContainer.classList.remove('fit-width');
-            // Center scroll position when switching to Original
-            setTimeout(centerSvgScroll, 10);
-        }
+        applySizeMode(this.value, true);
+        publishUrlState();
     });
 });
 
+function applySizeMode(sizeMode, explicit = false) {
+    const svgContainer = document.getElementById('svg-container');
+    if (!svgContainer || (sizeMode !== 'fit' && sizeMode !== 'original')) return;
+    hasExplicitSizeMode = hasExplicitSizeMode || explicit;
+    const radio = document.querySelector('input[name="sizeMode"][value="' + sizeMode + '"]');
+    if (radio) radio.checked = true;
+    if (sizeMode === 'fit') {
+        svgContainer.classList.add('fit-width');
+    } else {
+        svgContainer.classList.remove('fit-width');
+        setTimeout(centerSvgScroll, 10);
+    }
+}
+
 // Auto-select size mode based on SVG width vs container width
 function autoSelectSizeMode() {
+    if (hasExplicitSizeMode) return;
     const svgContainer = document.getElementById('svg-container');
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
@@ -885,6 +1016,7 @@ function autoSelectSizeMode() {
 
     // Use setTimeout to allow reflow before measuring
     setTimeout(() => {
+        if (hasExplicitSizeMode) return;
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
@@ -899,6 +1031,48 @@ function autoSelectSizeMode() {
     }, 0);
 }
 
+async function applyUrlState(state) {
+    isApplyingUrlState = true;
+    try {
+        const nextState = state || readUrlState();
+        currentDescriptorHash = nextState.hash || '';
+
+        document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
+            const tag = checkbox.getAttribute('data-tag');
+            checkbox.checked = Boolean(tag && nextState.tag.includes(tag));
+        });
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        }
+
+        const currentLabelMode = getCurrentLabelMode();
+        const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
+        if (labelRadio) labelRadio.checked = true;
+        if (currentLabelMode !== nextState.label) {
+            await regenerateSvg(nextState.label);
+        }
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        } else {
+            autoSelectSizeMode();
+        }
+        applySelectedTagsToDiagram();
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
+    } finally {
+        isApplyingUrlState = false;
+    }
+}
+
+window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'applyUrlState') {
+        applyUrlState(event.data.state);
+    }
+});
+
 // Center horizontal scroll position (for Original mode)
 function centerSvgScroll() {
     const svgContainer = document.getElementById('svg-container');
@@ -911,6 +1085,7 @@ function centerSvgScroll() {
 }
 
 // Run once when DOM is ready and on window resize
+applyUrlState();
 document.addEventListener('DOMContentLoaded', autoSelectSizeMode);
 window.addEventListener('resize', autoSelectSizeMode);
 </script>

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -14,6 +14,7 @@ class AlpsEditor {
         // Portable static detection: prefer explicit flag; default to static when flag is absent
         const hasApi = (typeof window.ALPSEDITOR_HAS_API === 'boolean') ? window.ALPSEDITOR_HAS_API : false;
         this.isStaticMode = !hasApi || this.isLocalMode;
+        this.initialUrlState = this.readSharedUrlState();
         // Ensure static/local environments use client-side diagramming before first preview
         if (this.isLocalMode || this.isStaticMode) {
             this.adapterManager.setAdapter('alps2dot');
@@ -325,11 +326,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const previousMode = this.previousViewMode || 'document';
             selector.value = previousMode;
             this.applyViewMode(previousMode);
+            this.replaceSharedUrlState({ view: previousMode });
         } else {
             // Save current mode and switch to preview
             this.previousViewMode = selector.value;
             selector.value = 'preview';
             this.applyViewMode('preview');
+            this.replaceSharedUrlState({ view: 'preview' });
         }
     }
 
@@ -430,12 +433,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const url = await this.adapterManager.generateDiagram(content, fileType);
 
             const iframe = document.getElementById('preview-frame');
-            iframe.src = url;
             // Apply view mode after iframe loads
             iframe.onload = () => {
                 const mode = document.getElementById('viewMode')?.value || 'document';
                 this.applyViewMode(mode);
+                this.applyDiagramUrlStateToFrame();
             };
+            iframe.src = url;
             this.debugLog('Preview updated');
             this.updateValidationMark(true);
             this.displayErrors([]);
@@ -453,6 +457,78 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         }
     }
 
+    getTagsFromValues(values) {
+        return values
+            .flatMap(value => String(value).split(','))
+            .map(tag => tag.trim())
+            .filter(Boolean);
+    }
+
+    readSharedUrlState() {
+        const params = new URLSearchParams(window.location.search);
+        const rawView = params.get('view');
+        const rawLabel = params.get('label');
+        const rawSize = params.get('size');
+        return {
+            view: ['document', 'diagram', 'preview'].includes(rawView) ? rawView : 'document',
+            tag: this.getTagsFromValues(params.getAll('tag')),
+            label: rawLabel === 'title' ? 'title' : 'id',
+            size: rawSize === 'fit' || rawSize === 'original' ? rawSize : '',
+            hash: window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : ''
+        };
+    }
+
+    replaceSharedUrlState(nextState) {
+        const currentState = this.readSharedUrlState();
+        const state = { ...currentState, ...nextState };
+        const url = new URL(window.location.href);
+
+        if (state.view && state.view !== 'document') {
+            url.searchParams.set('view', state.view);
+        } else {
+            url.searchParams.delete('view');
+        }
+
+        url.searchParams.delete('tag');
+        if (Array.isArray(state.tag) && state.tag.length > 0) {
+            url.searchParams.set('tag', state.tag.join(','));
+        }
+
+        if (state.label === 'title') {
+            url.searchParams.set('label', 'title');
+        } else {
+            url.searchParams.delete('label');
+        }
+
+        if (state.size === 'fit' || state.size === 'original') {
+            url.searchParams.set('size', state.size);
+        } else {
+            url.searchParams.delete('size');
+        }
+
+        url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+        window.history.replaceState(null, '', url.toString());
+    }
+
+    getDiagramUrlState() {
+        const state = this.readSharedUrlState();
+        return {
+            tag: state.tag,
+            label: state.label,
+            size: state.size,
+            hash: state.hash
+        };
+    }
+
+    applyDiagramUrlStateToFrame() {
+        const iframe = document.getElementById('preview-frame');
+        if (!iframe?.contentWindow) return;
+        iframe.contentWindow.postMessage({
+            type: 'applyUrlState',
+            state: this.getDiagramUrlState()
+        }, '*');
+    }
+
     setupAdapterSelector() {
         // Always use alps2dot adapter
         this.adapterManager.setAdapter('alps2dot');
@@ -462,13 +538,14 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         const selector = document.getElementById('viewMode');
         if (!selector) return;
 
-        // Always start with Document mode (default)
-        selector.value = 'document';
+        selector.value = this.initialUrlState.view;
 
         selector.addEventListener('change', (event) => {
             const mode = event.target.value;
             this.applyViewMode(mode);
+            this.replaceSharedUrlState({ view: mode });
         });
+        this.applyViewMode(selector.value);
     }
 
     applyViewMode(mode) {
@@ -863,11 +940,17 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         // Listen for messages from iframe diagram
         window.addEventListener('message', (event) => {
             // Validate origin for defense-in-depth security
-            if (event.origin !== window.location.origin) return;
+            const previewFrame = document.getElementById('preview-frame');
+            if (event.source !== previewFrame?.contentWindow && event.origin !== window.location.origin) return;
+
+            if (event.data && event.data.type === 'diagramStateChanged') {
+                this.replaceSharedUrlState(event.data.state || {});
+            }
 
             if (event.data && event.data.type === 'jumpToId') {
                 const id = event.data.id;
                 console.log('Jumping to ID:', id);
+                this.replaceSharedUrlState({ hash: id });
 
                 // In Preview mode, scroll to table row instead of editor
                 const viewMode = document.getElementById('viewMode')?.value;

--- a/packages/cli/src/generator/html-generator.ts
+++ b/packages/cli/src/generator/html-generator.ts
@@ -174,6 +174,17 @@ function scrollToDescriptor(id) {
     }
 }
 
+function setDescriptorHash(id) {
+    if (!id) return;
+    if (window.updateDiagramHash) {
+        window.updateDiagramHash(id);
+        return;
+    }
+    const url = new URL(window.location.href);
+    url.hash = '#' + encodeURIComponent(id);
+    window.history.replaceState(null, '', url.toString());
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     // Add click handlers to all SVG elements with href="#something"
     const svgLinks = document.querySelectorAll('svg a[href^="#"], svg a[*|href^="#"]');
@@ -186,6 +197,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const href = this.getAttribute('href') || this.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
             if (href && href.startsWith('#')) {
                 const id = href.substring(1);
+                setDescriptorHash(id);
                 scrollToDescriptor(id);
             }
         });
@@ -212,6 +224,7 @@ document.addEventListener('DOMContentLoaded', function() {
             // Scroll to target row if different
             const currentRow = this.closest('tr');
             const targetRow = document.getElementById('descriptor-' + id);
+            if (targetRow) setDescriptorHash(id);
 
             if (targetRow && targetRow !== currentRow) {
                 targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -299,6 +312,93 @@ ${linksHtml}
 <script>
 // Tag filtering
 const tagDescriptorMap = ${escapeJsonForScript(tagDescriptorMap)};
+let isApplyingUrlState = false;
+let hasExplicitSizeMode = false;
+let currentDescriptorHash = '';
+
+const getTagsFromValues = (values) => {
+    return values
+        .flatMap(value => String(value).split(','))
+        .map(tag => tag.trim())
+        .filter(tag => tag && Object.prototype.hasOwnProperty.call(tagDescriptorMap, tag));
+};
+
+const getCurrentHash = () => {
+    return window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : '';
+};
+
+const getCurrentLabelMode = () => {
+    return document.querySelector('input[name="labelMode"]:checked')?.value || 'id';
+};
+
+const getCurrentSizeMode = () => {
+    return document.querySelector('input[name="sizeMode"]:checked')?.value || 'original';
+};
+
+const getSelectedTags = () => {
+    return Array.from(document.querySelectorAll('.tag-trigger-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.getAttribute('data-tag'))
+        .filter(Boolean);
+};
+
+const readUrlState = () => {
+    const params = new URLSearchParams(window.location.search);
+    const label = params.get('label') === 'title' ? 'title' : 'id';
+    const rawSize = params.get('size');
+    const size = rawSize === 'fit' || rawSize === 'original' ? rawSize : '';
+    return {
+        tag: getTagsFromValues(params.getAll('tag')),
+        label,
+        size,
+        hash: getCurrentHash()
+    };
+};
+
+const collectUrlState = () => {
+    return {
+        tag: getSelectedTags(),
+        label: getCurrentLabelMode(),
+        size: getCurrentSizeMode(),
+        hash: currentDescriptorHash || getCurrentHash()
+    };
+};
+
+const replaceUrlState = (state) => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tag');
+    if (state.tag.length > 0) {
+        url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.label === 'title') {
+        url.searchParams.set('label', 'title');
+    } else {
+        url.searchParams.delete('label');
+    }
+    if (state.size === 'fit' || state.size === 'original') {
+        url.searchParams.set('size', state.size);
+    } else {
+        url.searchParams.delete('size');
+    }
+    url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+    window.history.replaceState(null, '', url.toString());
+};
+
+const publishUrlState = () => {
+    if (isApplyingUrlState) return;
+    hasExplicitSizeMode = true;
+    const state = collectUrlState();
+    if (window.parent !== window) {
+        window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
+    } else {
+        replaceUrlState(state);
+    }
+};
+
+window.updateDiagramHash = (id) => {
+    currentDescriptorHash = id || '';
+    publishUrlState();
+};
 
 const changeColorByTitle = (titleOrClass, newNodeColor, newEdgeColor, highlight = false) => {
     const elements = Array.from(document.getElementsByTagName('g'));
@@ -339,13 +439,21 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', function() {
-            const tag = this.getAttribute('data-tag');
-            this.checked ?
-                document.dispatchEvent(new CustomEvent('tagon-' + tag)) :
-                document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+            applySelectedTagsToDiagram();
+            publishUrlState();
         });
     });
 };
+
+function applySelectedTagsToDiagram() {
+    const selectedTags = new Set(getSelectedTags());
+    Object.keys(tagDescriptorMap).forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+    });
+    selectedTags.forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagon-' + tag));
+    });
+}
 
 const tagColors = ['LightGreen', 'SkyBlue', 'LightCoral', 'LightSalmon', 'Khaki', 'Plum', 'Wheat'];
 let colorIndex = 0;
@@ -442,6 +550,15 @@ async function regenerateSvg(labelMode) {
         const vizInstance = new Viz();
         const svgString = await vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
+        applySelectedTagsToDiagram();
+        if (hasExplicitSizeMode) {
+            applySizeMode(getCurrentSizeMode());
+        } else {
+            autoSelectSizeMode();
+        }
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
     } catch (error) {
         console.error('Error regenerating SVG:', error);
         svgGraph.innerHTML = '<p style="color:red;">Error regenerating diagram: ' + error.message + '</p>';
@@ -450,24 +567,34 @@ async function regenerateSvg(labelMode) {
 
 document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        regenerateSvg(this.value);
+        regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
 
 // Size mode toggle
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        const svgContainer = document.getElementById('svg-container');
-        if (this.value === 'fit') {
-            svgContainer.classList.add('fit-width');
-        } else {
-            svgContainer.classList.remove('fit-width');
-            setTimeout(centerSvgScroll, 10);
-        }
+        applySizeMode(this.value, true);
+        publishUrlState();
     });
 });
 
+function applySizeMode(sizeMode, explicit = false) {
+    const svgContainer = document.getElementById('svg-container');
+    if (!svgContainer || (sizeMode !== 'fit' && sizeMode !== 'original')) return;
+    hasExplicitSizeMode = hasExplicitSizeMode || explicit;
+    const radio = document.querySelector('input[name="sizeMode"][value="' + sizeMode + '"]');
+    if (radio) radio.checked = true;
+    if (sizeMode === 'fit') {
+        svgContainer.classList.add('fit-width');
+    } else {
+        svgContainer.classList.remove('fit-width');
+        setTimeout(centerSvgScroll, 10);
+    }
+}
+
 function autoSelectSizeMode() {
+    if (hasExplicitSizeMode) return;
     const svgContainer = document.getElementById('svg-container');
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
@@ -478,6 +605,7 @@ function autoSelectSizeMode() {
     svgContainer.classList.remove('fit-width');
 
     setTimeout(() => {
+        if (hasExplicitSizeMode) return;
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
@@ -491,6 +619,48 @@ function autoSelectSizeMode() {
     }, 0);
 }
 
+async function applyUrlState(state) {
+    isApplyingUrlState = true;
+    try {
+        const nextState = state || readUrlState();
+        currentDescriptorHash = nextState.hash || '';
+
+        document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
+            const tag = checkbox.getAttribute('data-tag');
+            checkbox.checked = Boolean(tag && nextState.tag.includes(tag));
+        });
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        }
+
+        const currentLabelMode = getCurrentLabelMode();
+        const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
+        if (labelRadio) labelRadio.checked = true;
+        if (currentLabelMode !== nextState.label) {
+            await regenerateSvg(nextState.label);
+        }
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        } else {
+            autoSelectSizeMode();
+        }
+        applySelectedTagsToDiagram();
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
+    } finally {
+        isApplyingUrlState = false;
+    }
+}
+
+window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'applyUrlState') {
+        applyUrlState(event.data.state);
+    }
+});
+
 function centerSvgScroll() {
     const svgContainer = document.getElementById('svg-container');
     if (svgContainer && !svgContainer.classList.contains('fit-width')) {
@@ -501,6 +671,7 @@ function centerSvgScroll() {
     }
 }
 
+applyUrlState();
 document.addEventListener('DOMContentLoaded', autoSelectSizeMode);
 window.addEventListener('resize', autoSelectSizeMode);
 

--- a/public/js/diagramAdapters.js
+++ b/public/js/diagramAdapters.js
@@ -406,6 +406,17 @@ function scrollToDescriptor(id) {
     }
 }
 
+function setDescriptorHash(id) {
+    if (!id) return;
+    if (window.updateDiagramHash) {
+        window.updateDiagramHash(id);
+        return;
+    }
+    const url = new URL(window.location.href);
+    url.hash = '#' + encodeURIComponent(id);
+    window.history.replaceState(null, '', url.toString());
+}
+
 // Listen for messages from parent (for Preview mode scroll)
 window.addEventListener('message', function(event) {
     if (event.data && event.data.type === 'scrollToDescriptor') {
@@ -436,6 +447,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (href && href.startsWith('#')) {
                 const id = href.substring(1);
                 console.log('Extracted ID:', id);
+                setDescriptorHash(id);
 
                 if (window.parent !== window) {
                     // In iframe (editor mode): Send message to parent window
@@ -462,8 +474,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 href = href.substring(1);
             }
             const id = href.substring(1);
+            const currentRow = this.closest('tr');
+            const targetRow = document.getElementById('descriptor-' + id);
+            const hasDescriptorTarget = Boolean(targetRow);
+            if (hasDescriptorTarget) setDescriptorHash(id);
 
-            if (window.parent !== window) {
+            if (window.parent !== window && hasDescriptorTarget) {
                 // In iframe (editor mode): Send message to parent to jump to editor line
                 window.parent.postMessage({
                     type: 'jumpToId',
@@ -483,8 +499,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             // Check if this is a link to a different row (rt/Contained) or self (ID column)
-            const currentRow = this.closest('tr');
-            const targetRow = document.getElementById('descriptor-' + id);
 
             // Only scroll and highlight if linking to a different row
             if (targetRow && targetRow !== currentRow) {
@@ -646,12 +660,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 e.stopPropagation();
                 const id = href.substring(1);
                 console.log('Document click - extracted ID:', id);
+                if (!document.getElementById('descriptor-' + id)) return;
+                setDescriptorHash(id);
                 
                 if (window.parent !== window) {
                     window.parent.postMessage({
                         type: 'jumpToId',
                         id: id
                     }, '*');
+                } else {
+                    scrollToDescriptor(id);
                 }
             }
         }
@@ -691,6 +709,93 @@ ${linksHtml}
 
 // Tag filtering - using same logic as production ASD
 const tagDescriptorMap = ${escapeJsonForScript(tagDescriptorMap)};
+let isApplyingUrlState = false;
+let hasExplicitSizeMode = false;
+let currentDescriptorHash = '';
+
+const getTagsFromValues = (values) => {
+    return values
+        .flatMap(value => String(value).split(','))
+        .map(tag => tag.trim())
+        .filter(tag => tag && Object.prototype.hasOwnProperty.call(tagDescriptorMap, tag));
+};
+
+const getCurrentHash = () => {
+    return window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : '';
+};
+
+const getCurrentLabelMode = () => {
+    return document.querySelector('input[name="labelMode"]:checked')?.value || 'id';
+};
+
+const getCurrentSizeMode = () => {
+    return document.querySelector('input[name="sizeMode"]:checked')?.value || 'original';
+};
+
+const getSelectedTags = () => {
+    return Array.from(document.querySelectorAll('.tag-trigger-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.getAttribute('data-tag'))
+        .filter(Boolean);
+};
+
+const readUrlState = () => {
+    const params = new URLSearchParams(window.location.search);
+    const label = params.get('label') === 'title' ? 'title' : 'id';
+    const rawSize = params.get('size');
+    const size = rawSize === 'fit' || rawSize === 'original' ? rawSize : '';
+    return {
+        tag: getTagsFromValues(params.getAll('tag')),
+        label,
+        size,
+        hash: getCurrentHash()
+    };
+};
+
+const collectUrlState = () => {
+    return {
+        tag: getSelectedTags(),
+        label: getCurrentLabelMode(),
+        size: getCurrentSizeMode(),
+        hash: currentDescriptorHash || getCurrentHash()
+    };
+};
+
+const replaceUrlState = (state) => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('tag');
+    if (state.tag.length > 0) {
+        url.searchParams.set('tag', state.tag.join(','));
+    }
+    if (state.label === 'title') {
+        url.searchParams.set('label', 'title');
+    } else {
+        url.searchParams.delete('label');
+    }
+    if (state.size === 'fit' || state.size === 'original') {
+        url.searchParams.set('size', state.size);
+    } else {
+        url.searchParams.delete('size');
+    }
+    url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+    window.history.replaceState(null, '', url.toString());
+};
+
+const publishUrlState = () => {
+    if (isApplyingUrlState) return;
+    hasExplicitSizeMode = true;
+    const state = collectUrlState();
+    if (window.parent !== window) {
+        window.parent.postMessage({ type: 'diagramStateChanged', state }, '*');
+    } else {
+        replaceUrlState(state);
+    }
+};
+
+window.updateDiagramHash = (id) => {
+    currentDescriptorHash = id || '';
+    publishUrlState();
+};
 
 // Changes color of SVG elements by title (matching production ASD)
 const changeColorByTitle = (titleOrClass, newNodeColor, newEdgeColor, highlight = false) => {
@@ -736,13 +841,21 @@ const setupTagTrigger = () => {
     const checkboxes = document.querySelectorAll('.tag-trigger-checkbox');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', function() {
-            const tag = this.getAttribute('data-tag');
-            this.checked ?
-                document.dispatchEvent(new CustomEvent('tagon-' + tag)) :
-                document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+            applySelectedTagsToDiagram();
+            publishUrlState();
         });
     });
 };
+
+function applySelectedTagsToDiagram() {
+    const selectedTags = new Set(getSelectedTags());
+    Object.keys(tagDescriptorMap).forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagoff-' + tag));
+    });
+    selectedTags.forEach(tag => {
+        document.dispatchEvent(new CustomEvent('tagon-' + tag));
+    });
+}
 
 // Tag colors (cycle through for multiple tags)
 const tagColors = ['LightGreen', 'SkyBlue', 'LightCoral', 'LightSalmon', 'Khaki', 'Plum', 'Wheat'];
@@ -844,6 +957,15 @@ async function regenerateSvg(labelMode) {
         const vizInstance = new Viz();
         const svgString = await vizInstance.renderString(dotContent, { format: 'svg' });
         svgGraph.innerHTML = svgString;
+        applySelectedTagsToDiagram();
+        if (hasExplicitSizeMode) {
+            applySizeMode(getCurrentSizeMode());
+        } else {
+            autoSelectSizeMode();
+        }
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
         console.log('SVG regenerated with labelMode:', labelMode);
     } catch (error) {
         console.error('Error regenerating SVG:', error);
@@ -853,26 +975,35 @@ async function regenerateSvg(labelMode) {
 
 document.querySelectorAll('input[name="labelMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        regenerateSvg(this.value);
+        regenerateSvg(this.value).then(() => publishUrlState());
     });
 });
 
 // Size mode toggle (Original / Fit to width)
 document.querySelectorAll('input[name="sizeMode"]').forEach(radio => {
     radio.addEventListener('change', function() {
-        const svgContainer = document.getElementById('svg-container');
-        if (this.value === 'fit') {
-            svgContainer.classList.add('fit-width');
-        } else {
-            svgContainer.classList.remove('fit-width');
-            // Center scroll position when switching to Original
-            setTimeout(centerSvgScroll, 10);
-        }
+        applySizeMode(this.value, true);
+        publishUrlState();
     });
 });
 
+function applySizeMode(sizeMode, explicit = false) {
+    const svgContainer = document.getElementById('svg-container');
+    if (!svgContainer || (sizeMode !== 'fit' && sizeMode !== 'original')) return;
+    hasExplicitSizeMode = hasExplicitSizeMode || explicit;
+    const radio = document.querySelector('input[name="sizeMode"][value="' + sizeMode + '"]');
+    if (radio) radio.checked = true;
+    if (sizeMode === 'fit') {
+        svgContainer.classList.add('fit-width');
+    } else {
+        svgContainer.classList.remove('fit-width');
+        setTimeout(centerSvgScroll, 10);
+    }
+}
+
 // Auto-select size mode based on SVG width vs container width
 function autoSelectSizeMode() {
+    if (hasExplicitSizeMode) return;
     const svgContainer = document.getElementById('svg-container');
     const svgElement = document.querySelector('#svg-graph svg');
     const fitRadio = document.querySelector('input[name="sizeMode"][value="fit"]');
@@ -885,6 +1016,7 @@ function autoSelectSizeMode() {
 
     // Use setTimeout to allow reflow before measuring
     setTimeout(() => {
+        if (hasExplicitSizeMode) return;
         const svgWidth = svgElement.getBoundingClientRect().width;
         const containerWidth = svgContainer.clientWidth;
 
@@ -899,6 +1031,48 @@ function autoSelectSizeMode() {
     }, 0);
 }
 
+async function applyUrlState(state) {
+    isApplyingUrlState = true;
+    try {
+        const nextState = state || readUrlState();
+        currentDescriptorHash = nextState.hash || '';
+
+        document.querySelectorAll('.tag-trigger-checkbox').forEach(checkbox => {
+            const tag = checkbox.getAttribute('data-tag');
+            checkbox.checked = Boolean(tag && nextState.tag.includes(tag));
+        });
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        }
+
+        const currentLabelMode = getCurrentLabelMode();
+        const labelRadio = document.querySelector('input[name="labelMode"][value="' + nextState.label + '"]');
+        if (labelRadio) labelRadio.checked = true;
+        if (currentLabelMode !== nextState.label) {
+            await regenerateSvg(nextState.label);
+        }
+
+        if (nextState.size) {
+            applySizeMode(nextState.size, true);
+        } else {
+            autoSelectSizeMode();
+        }
+        applySelectedTagsToDiagram();
+        if (currentDescriptorHash) {
+            setTimeout(() => scrollToDescriptor(currentDescriptorHash), 0);
+        }
+    } finally {
+        isApplyingUrlState = false;
+    }
+}
+
+window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'applyUrlState') {
+        applyUrlState(event.data.state);
+    }
+});
+
 // Center horizontal scroll position (for Original mode)
 function centerSvgScroll() {
     const svgContainer = document.getElementById('svg-container');
@@ -911,6 +1085,7 @@ function centerSvgScroll() {
 }
 
 // Run once when DOM is ready and on window resize
+applyUrlState();
 document.addEventListener('DOMContentLoaded', autoSelectSizeMode);
 window.addEventListener('resize', autoSelectSizeMode);
 </script>

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -14,6 +14,7 @@ class AlpsEditor {
         // Portable static detection: prefer explicit flag; default to static when flag is absent
         const hasApi = (typeof window.ALPSEDITOR_HAS_API === 'boolean') ? window.ALPSEDITOR_HAS_API : false;
         this.isStaticMode = !hasApi || this.isLocalMode;
+        this.initialUrlState = this.readSharedUrlState();
         // Ensure static/local environments use client-side diagramming before first preview
         if (this.isLocalMode || this.isStaticMode) {
             this.adapterManager.setAdapter('alps2dot');
@@ -317,11 +318,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const previousMode = this.previousViewMode || 'document';
             selector.value = previousMode;
             this.applyViewMode(previousMode);
+            this.replaceSharedUrlState({ view: previousMode });
         } else {
             // Save current mode and switch to preview
             this.previousViewMode = selector.value;
             selector.value = 'preview';
             this.applyViewMode('preview');
+            this.replaceSharedUrlState({ view: 'preview' });
         }
     }
 
@@ -422,12 +425,13 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
             const url = await this.adapterManager.generateDiagram(content, fileType);
 
             const iframe = document.getElementById('preview-frame');
-            iframe.src = url;
             // Apply view mode after iframe loads
             iframe.onload = () => {
                 const mode = document.getElementById('viewMode')?.value || 'document';
                 this.applyViewMode(mode);
+                this.applyDiagramUrlStateToFrame();
             };
+            iframe.src = url;
             this.debugLog('Preview updated');
             this.updateValidationMark(true);
             this.displayErrors([]);
@@ -445,6 +449,78 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         }
     }
 
+    getTagsFromValues(values) {
+        return values
+            .flatMap(value => String(value).split(','))
+            .map(tag => tag.trim())
+            .filter(Boolean);
+    }
+
+    readSharedUrlState() {
+        const params = new URLSearchParams(window.location.search);
+        const rawView = params.get('view');
+        const rawLabel = params.get('label');
+        const rawSize = params.get('size');
+        return {
+            view: ['document', 'diagram', 'preview'].includes(rawView) ? rawView : 'document',
+            tag: this.getTagsFromValues(params.getAll('tag')),
+            label: rawLabel === 'title' ? 'title' : 'id',
+            size: rawSize === 'fit' || rawSize === 'original' ? rawSize : '',
+            hash: window.location.hash ? decodeURIComponent(window.location.hash.substring(1)) : ''
+        };
+    }
+
+    replaceSharedUrlState(nextState) {
+        const currentState = this.readSharedUrlState();
+        const state = { ...currentState, ...nextState };
+        const url = new URL(window.location.href);
+
+        if (state.view && state.view !== 'document') {
+            url.searchParams.set('view', state.view);
+        } else {
+            url.searchParams.delete('view');
+        }
+
+        url.searchParams.delete('tag');
+        if (Array.isArray(state.tag) && state.tag.length > 0) {
+            url.searchParams.set('tag', state.tag.join(','));
+        }
+
+        if (state.label === 'title') {
+            url.searchParams.set('label', 'title');
+        } else {
+            url.searchParams.delete('label');
+        }
+
+        if (state.size === 'fit' || state.size === 'original') {
+            url.searchParams.set('size', state.size);
+        } else {
+            url.searchParams.delete('size');
+        }
+
+        url.hash = state.hash ? '#' + encodeURIComponent(state.hash) : '';
+        window.history.replaceState(null, '', url.toString());
+    }
+
+    getDiagramUrlState() {
+        const state = this.readSharedUrlState();
+        return {
+            tag: state.tag,
+            label: state.label,
+            size: state.size,
+            hash: state.hash
+        };
+    }
+
+    applyDiagramUrlStateToFrame() {
+        const iframe = document.getElementById('preview-frame');
+        if (!iframe?.contentWindow) return;
+        iframe.contentWindow.postMessage({
+            type: 'applyUrlState',
+            state: this.getDiagramUrlState()
+        }, '*');
+    }
+
     setupAdapterSelector() {
         // Always use alps2dot adapter
         this.adapterManager.setAdapter('alps2dot');
@@ -454,13 +530,14 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         const selector = document.getElementById('viewMode');
         if (!selector) return;
 
-        // Always start with Document mode (default)
-        selector.value = 'document';
+        selector.value = this.initialUrlState.view;
 
         selector.addEventListener('change', (event) => {
             const mode = event.target.value;
             this.applyViewMode(mode);
+            this.replaceSharedUrlState({ view: mode });
         });
+        this.applyViewMode(selector.value);
     }
 
     applyViewMode(mode) {
@@ -855,11 +932,17 @@ Happy modeling! Remember, solid semantics supports the long-term evolution of yo
         // Listen for messages from iframe diagram
         window.addEventListener('message', (event) => {
             // Validate origin for defense-in-depth security
-            if (event.origin !== window.location.origin) return;
+            const previewFrame = document.getElementById('preview-frame');
+            if (event.source !== previewFrame?.contentWindow && event.origin !== window.location.origin) return;
+
+            if (event.data && event.data.type === 'diagramStateChanged') {
+                this.replaceSharedUrlState(event.data.state || {});
+            }
 
             if (event.data && event.data.type === 'jumpToId') {
                 const id = event.data.id;
                 console.log('Jumping to ID:', id);
+                this.replaceSharedUrlState({ hash: id });
 
                 // In Preview mode, scroll to table row instead of editor
                 const viewMode = document.getElementById('viewMode')?.value;


### PR DESCRIPTION
## Summary

- Add URL state parsing and realtime URL updates for generated standalone HTML (`tag`, `label`, `size`, and descriptor fragment).
- Add the same URL state behavior to browser preview generation and docs mirror assets.
- Sync editor parent URL state with preview iframe state, including `view=document|diagram|preview`.

## Validation

- `pnpm -r build` passed.
- `node --check public/js/diagramAdapters.js public/js/scripts.js docs/js/diagramAdapters.js docs/js/scripts.js` passed.
- Browser manual verification passed for `?tag=cart,catalog&label=title&size=fit#ShoppingCart`, including URL updates after tag interaction.
- `pnpm -r test` exits with code 1 because Jest reports no tests found for `@alps-asd/cli` in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagram state (selected tags, label/size modes, current descriptor position) now persists in the URL and survives browser refreshes, making diagram views bookmarkable and shareable
  * Enhanced cross-window messaging for coordinated state synchronization between editor and embedded diagram viewers

* **Refactor**
  * Optimized navigation and state-management handling throughout the editor and diagram interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->