### PR TITLE
Add MCP server with auto-externalized descriptor docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ pnpm --filter @alps-asd/cli test
 | `generator/table-functions.ts` | Table utilities (ported from JS) |
 | `resolver/file-resolver.ts` | External reference resolution |
 | `mcp/server.ts` | MCP server tools (overview, search, paths, set_doc) |
-| `mcp/doc-store.ts` | Doc externalization (alps-doc/<id>.md via doc.href) |
+| `mcp/doc-store.ts` | Doc externalization (alps/docs/<id>.md via doc.href) |
 | `mcp/graph.ts` | State graph extraction, path finding |
 | `mcp/validator.ts` | ALPS validation (E/W codes) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ ALPS (Application-Level Profile Semantics) tooling. Generates HTML documentation
 
 **Architecture**: Editor-first design. Browser editor (`/public/`) is the source of truth. CLI is a Node.js adapter.
 
-See [docs/architecture.md](docs/architecture.md) for detailed architecture documentation.
+See [dev-docs/architecture.md](dev-docs/architecture.md) for detailed architecture documentation.
 
 ## Project Structure
 
@@ -27,9 +27,11 @@ app-state-diagram/
 │           ├── asd.ts          # CLI entry point
 │           ├── parser/         # ALPS parsing (fast-xml-parser)
 │           ├── generator/      # DOT, SVG, HTML generation
-│           └── resolver/       # External reference resolution
+│           ├── resolver/       # External reference resolution
+│           └── mcp/            # MCP server (asd --mcp)
 │
-└── docs/
+├── docs/                       # GitHub Pages site
+└── dev-docs/
     ├── architecture.md
     └── adr/
 ```
@@ -49,6 +51,10 @@ node packages/cli/dist/asd.js profile.xml
 node packages/cli/dist/asd.js profile.json -f svg
 node packages/cli/dist/asd.js profile.json -f dot --echo
 node packages/cli/dist/asd.js profile.json --label title
+node packages/cli/dist/asd.js --mcp   # MCP server (stdio) for AI agents
+
+# Run tests
+pnpm --filter @alps-asd/cli test
 ```
 
 ## Key Files
@@ -72,6 +78,10 @@ node packages/cli/dist/asd.js profile.json --label title
 | `generator/html-generator.ts` | HTML document generation |
 | `generator/table-functions.ts` | Table utilities (ported from JS) |
 | `resolver/file-resolver.ts` | External reference resolution |
+| `mcp/server.ts` | MCP server tools (overview, search, paths, set_doc) |
+| `mcp/doc-store.ts` | Doc externalization (alps-doc/<id>.md via doc.href) |
+| `mcp/graph.ts` | State graph extraction, path finding |
+| `mcp/validator.ts` | ALPS validation (E/W codes) |
 
 ## Descriptor Types
 

--- a/README.md
+++ b/README.md
@@ -89,19 +89,29 @@ Example configuration for Claude Code (`.mcp.json`):
 }
 ```
 
-#### External Documentation (alps-doc/)
+#### Auxiliary Design Information (alps/)
 
 `alps_set_doc` keeps profiles compact while allowing rich documentation.
 Short single-line docs are stored inline. When a doc is large or multi-line
-(e.g. detailed Markdown), it is written to `alps-doc/<descriptor-id>.md`
+(e.g. detailed Markdown), it is written to `alps/docs/<descriptor-id>.md`
 next to the profile and linked via the ALPS `doc` element's `href`:
 
 ```json
 {
   "id": "ShoppingCart",
   "type": "semantic",
-  "doc": { "href": "alps-doc/ShoppingCart.md", "format": "markdown" }
+  "doc": { "href": "alps/docs/ShoppingCart.md", "format": "markdown" }
 }
+```
+
+The `alps/` directory is the home for all auxiliary design information:
+
+```text
+profile.json
+alps/
+├── docs/    # per-descriptor rich documentation (doc.href targets)
+├── rels/    # link relation definitions (rel="..." targets)
+└── links/   # compacted summaries of external link targets
 ```
 
 Reading tools (`alps_descriptor`) resolve these links and inline the file

--- a/README.md
+++ b/README.md
@@ -57,6 +57,56 @@ asd profile.json -f dot -o diagram.dot
 asd profile.json --validate
 ```
 
+### MCP Server (AI Agents)
+
+```bash
+# Run as an MCP server on stdio (for Claude Code, Claude Desktop, etc.)
+asd --mcp
+```
+
+Registers the ALPS profile as a queryable application state model for AI agents:
+
+| Tool | Description |
+|------|-------------|
+| `alps_overview` | Profile summary: states, transitions (from/to), tags |
+| `alps_validate` | Validation with error/warning codes |
+| `alps_search` | Filter descriptors by type, tag, or free text |
+| `alps_descriptor` | Full descriptor details with resolved documentation |
+| `alps_paths` | Enumerate transition paths between two states |
+| `alps_diagram` | Render the state diagram as DOT or SVG |
+| `alps_set_doc` | Set descriptor documentation (auto-externalized when large) |
+
+Example configuration for Claude Code (`.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "alps": {
+      "command": "asd",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+#### External Documentation (alps-doc/)
+
+`alps_set_doc` keeps profiles compact while allowing rich documentation.
+Short single-line docs are stored inline. When a doc is large or multi-line
+(e.g. detailed Markdown), it is written to `alps-doc/<descriptor-id>.md`
+next to the profile and linked via the ALPS `doc` element's `href`:
+
+```json
+{
+  "id": "ShoppingCart",
+  "type": "semantic",
+  "doc": { "href": "alps-doc/ShoppingCart.md", "format": "markdown" }
+}
+```
+
+Reading tools (`alps_descriptor`) resolve these links and inline the file
+content automatically.
+
 ## Output Example
 
 The generated HTML includes:

--- a/dev-docs/adr/0002-cli-feature-parity.md
+++ b/dev-docs/adr/0002-cli-feature-parity.md
@@ -45,6 +45,8 @@ TypeScript版CLI (`@alps-asd/cli`) をPHP版 (`bin/asd`) と互換性を持た�
 |-----------|------|------|
 | `--mcp` | Claude Desktop統合用MCPサーバー | PHP版で動作確認済み。MCPはJSON-RPC over stdioで言語非依存。書き直しリスクを避け、動作しているコードを維持。 |
 
+> **Note**: この判断は [ADR 0003](0003-mcp-server.md) で更新され、MCPサーバーはTypeScript版CLIに実装された（`asd --mcp`）。
+
 ### 不要と判断した機能
 
 | オプション | 説明 | 理由 |

--- a/dev-docs/adr/0002-cli-feature-parity.md
+++ b/dev-docs/adr/0002-cli-feature-parity.md
@@ -72,6 +72,6 @@ Profile file not found: filename
 
 - PHP版ユーザーが違和感なくTS版に移行できる
 - watchモードはCDP経由で実装完了（Tag/Table更新は Editor 統合待ち）
-- MCPは PHP 版を別リポジトリで維持
+- MCPは ADR 0003 で TypeScript 版CLIに実装（`asd --mcp`）。PHP版の維持は不要に
 - 設定ファイル機能は省略（シンプルさを優先）
 - Editor を UI の SSOT とすることで将来の機能追加が CLI に影響しない設計

--- a/dev-docs/adr/0003-mcp-server.md
+++ b/dev-docs/adr/0003-mcp-server.md
@@ -35,7 +35,7 @@ Inline `doc` values keep profiles readable only while they stay short.
 For rich documentation, the doc is stored in an external Markdown file
 and linked via the ALPS `doc` element's `href` attribute:
 
-```
+```text
 profile.json
 alps-doc/
 ├── ShoppingCart.md
@@ -66,6 +66,8 @@ but never deleted.
   `moduleResolution: node`.
 - `alps_set_doc` edits the raw JSON (not the normalized parse) so the
   rest of the profile is preserved, including indentation style.
+- `doc.href` paths are constrained to the profile directory: schemes,
+  absolute paths, and `../` traversal are never read or written.
 - Writing is JSON-only for now; XML write-back would reformat the whole
   document. Read tools support both formats.
 

--- a/dev-docs/adr/0003-mcp-server.md
+++ b/dev-docs/adr/0003-mcp-server.md
@@ -29,21 +29,37 @@ transport) with tools for querying and modifying ALPS profiles:
 - `alps_diagram` — DOT/SVG rendering
 - `alps_set_doc` — documentation writing
 
-### External Documentation Convention (alps-doc/)
+### Auxiliary Design Information Convention (alps/)
 
 Inline `doc` values keep profiles readable only while they stay short.
 For rich documentation, the doc is stored in an external Markdown file
-and linked via the ALPS `doc` element's `href` attribute:
+and linked via the ALPS `doc` element's `href` attribute. All auxiliary
+design information lives under a single `alps/` directory next to the
+profile:
 
 ```text
 profile.json
-alps-doc/
-├── ShoppingCart.md
-└── Checkout.md
+alps/
+├── docs/                 # per-descriptor rich documentation (doc.href)
+│   ├── ShoppingCart.md
+│   └── Checkout.md
+├── rels/                 # link relation definitions (link rel="..." targets)
+│   └── issue.md
+└── links/                # external link targets, pre-compacted for agents
+    └── tax-rules.md      # (summary of a linked external resource)
 ```
 
+- `docs/` is written by `alps_set_doc` and read back by `alps_descriptor`.
+- `rels/` holds definitions of custom link relations used in `link`
+  elements, one file per rel, addressable as `alps/rels/<rel>.md`.
+- `links/` holds agent-ready digests of external link targets — the
+  linked page's content compacted to the essentials (in the spirit of
+  skill files), so agents need not fetch and re-summarize the original.
+  `rels/` and `links/` are reserved conventions; tooling support beyond
+  read-through resolution is future work.
+
 ```json
-"doc": { "href": "alps-doc/ShoppingCart.md", "format": "markdown" }
+"doc": { "href": "alps/docs/ShoppingCart.md", "format": "markdown" }
 ```
 
 `alps_set_doc` decides the placement automatically (`placement: auto`):
@@ -51,8 +67,12 @@ alps-doc/
 | Condition | Placement |
 |-----------|-----------|
 | <= 200 chars, single line | inline |
-| > 200 chars or multi-line | external `alps-doc/<id>.md` |
+| > 200 chars or multi-line | external `alps/docs/<id>.md` |
 | descriptor already links a local doc file | stays external, same file (no churn) |
+
+Profiles using other layouts (e.g. a flat `alps-doc/`) keep working:
+any existing local `doc.href` is honored and updated in place; the
+`alps/docs/` default applies only when a doc is first externalized.
 
 Explicit `placement: inline | external` overrides the heuristic. When
 switching from external to inline, the old file is reported as orphaned
@@ -77,6 +97,6 @@ but never deleted.
   just an input for document generation.
 - The PHP `--mcp` is no longer the only MCP path; the TS version is the
   one maintained going forward.
-- The `alps-doc/` convention enables rich per-descriptor documentation
-  without bloating profiles. HTML output rendering of linked docs is
-  future work.
+- The `alps/` convention gives auxiliary design information (docs, link
+  relations, link digests) a single addressable home without bloating
+  profiles. HTML output rendering of linked docs is future work.

--- a/dev-docs/adr/0003-mcp-server.md
+++ b/dev-docs/adr/0003-mcp-server.md
@@ -1,0 +1,80 @@
+# ADR 0003: MCP Server in TypeScript CLI
+
+## Status
+
+Accepted (supersedes the MCP decision in ADR 0002)
+
+## Context
+
+ADR 0002 decided to keep the MCP server in the PHP version to avoid
+rewriting working code. Since then, the TypeScript CLI has gained all the
+building blocks an MCP server needs: parsing, external reference
+resolution, DOT/SVG generation, and validation. The official
+`@modelcontextprotocol/sdk` makes the protocol layer thin.
+
+The CLI generates documents in one shot. AI agents need something
+different: incremental, token-efficient access to the application state
+model — "what transitions leave this state?", "show me only the cart
+descriptors", "document this state" — without re-reading the whole
+profile each time.
+
+## Decision
+
+Implement the MCP server in the TypeScript CLI (`asd --mcp`, stdio
+transport) with tools for querying and modifying ALPS profiles:
+
+- `alps_overview`, `alps_search`, `alps_descriptor` — incremental reading
+- `alps_validate` — validation with README error codes (E001-, W001-)
+- `alps_paths` — path enumeration over the state graph
+- `alps_diagram` — DOT/SVG rendering
+- `alps_set_doc` — documentation writing
+
+### External Documentation Convention (alps-doc/)
+
+Inline `doc` values keep profiles readable only while they stay short.
+For rich documentation, the doc is stored in an external Markdown file
+and linked via the ALPS `doc` element's `href` attribute:
+
+```
+profile.json
+alps-doc/
+├── ShoppingCart.md
+└── Checkout.md
+```
+
+```json
+"doc": { "href": "alps-doc/ShoppingCart.md", "format": "markdown" }
+```
+
+`alps_set_doc` decides the placement automatically (`placement: auto`):
+
+| Condition | Placement |
+|-----------|-----------|
+| <= 200 chars, single line | inline |
+| > 200 chars or multi-line | external `alps-doc/<id>.md` |
+| descriptor already uses an alps-doc file | stays external (no churn) |
+
+Explicit `placement: inline | external` overrides the heuristic. When
+switching from external to inline, the old file is reported as orphaned
+but never deleted.
+
+### Implementation Notes
+
+- SDK imported as `@modelcontextprotocol/sdk/server/mcp.js`: runtime
+  resolves via the package `exports` map (CJS build), TypeScript types
+  via `typesVersions`. Deep `dist/` paths do not resolve under
+  `moduleResolution: node`.
+- `alps_set_doc` edits the raw JSON (not the normalized parse) so the
+  rest of the profile is preserved, including indentation style.
+- Writing is JSON-only for now; XML write-back would reformat the whole
+  document. Read tools support both formats.
+
+## Consequences
+
+- ALPS profiles become a queryable source of truth for AI agents, not
+  just an input for document generation.
+- The PHP `--mcp` is no longer the only MCP path; the TS version is the
+  one maintained going forward.
+- The `alps-doc/` convention enables rich per-descriptor documentation
+  without bloating profiles. HTML output rendering of linked docs is
+  future work.

--- a/dev-docs/adr/0003-mcp-server.md
+++ b/dev-docs/adr/0003-mcp-server.md
@@ -52,7 +52,7 @@ alps-doc/
 |-----------|-----------|
 | <= 200 chars, single line | inline |
 | > 200 chars or multi-line | external `alps-doc/<id>.md` |
-| descriptor already uses an alps-doc file | stays external (no churn) |
+| descriptor already links a local doc file | stays external, same file (no churn) |
 
 Explicit `placement: inline | external` overrides the heuristic. When
 switching from external to inline, the old file is reported as orphaned

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -23,9 +23,10 @@ app-state-diagram/
 │           ├── asd.ts          # CLI entry point
 │           ├── parser/         # ALPS parsing (fast-xml-parser)
 │           ├── generator/      # DOT, SVG, HTML generation
-│           └── resolver/       # External reference resolution
+│           ├── resolver/       # External reference resolution
+│           └── mcp/            # MCP server (asd --mcp, see ADR 0003)
 │
-├── docs/
+├── dev-docs/
 │   ├── architecture.md         # This file
 │   └── adr/                    # Architecture Decision Records
 │
@@ -50,6 +51,14 @@ Node.js CLI tool for generating HTML documentation from ALPS profiles.
 Key differences from browser:
 - Uses `fast-xml-parser` for XML parsing (browser uses `DOMParser`)
 - Uses `@viz-js/viz` (WASM) for SVG generation
+
+### MCP Server (asd --mcp)
+
+The CLI doubles as an MCP server (stdio) exposing the ALPS profile as a
+queryable application state model for AI agents: overview, descriptor
+search, path finding, diagram rendering, validation, and documentation
+writing. Large docs are externalized to `alps-doc/<id>.md` and linked via
+`doc.href`. See [ADR 0003](adr/0003-mcp-server.md).
 
 ## Shared Logic
 

--- a/dev-docs/architecture.md
+++ b/dev-docs/architecture.md
@@ -57,7 +57,7 @@ Key differences from browser:
 The CLI doubles as an MCP server (stdio) exposing the ALPS profile as a
 queryable application state model for AI agents: overview, descriptor
 search, path finding, diagram rendering, validation, and documentation
-writing. Large docs are externalized to `alps-doc/<id>.md` and linked via
+writing. Large docs are externalized to `alps/docs/<id>.md` and linked via
 `doc.href`. See [ADR 0003](adr/0003-mcp-server.md).
 
 ## Shared Logic

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,0 +1,20 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          target: 'ES2020',
+          module: 'CommonJS',
+          esModuleInterop: true,
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+    ],
+  },
+};

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,10 @@
   },
   "devDependencies": {
     "@types/chrome-remote-interface": "^0.33.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.8.0",
+    "jest": "^30.2.0",
+    "ts-jest": "^29.4.6",
     "typescript": "^5.2.2"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,11 +25,13 @@
   "author": "Akihito Koriyama <akihito.koriyama@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@viz-js/viz": "^3.11.0",
     "chokidar": "3",
     "chrome-remote-interface": "^0.33.3",
     "commander": "^11.1.0",
-    "fast-xml-parser": "^4.5.0"
+    "fast-xml-parser": "^4.5.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/chrome-remote-interface": "^0.33.0",

--- a/packages/cli/src/asd.ts
+++ b/packages/cli/src/asd.ts
@@ -14,6 +14,7 @@ import { dotToSvg, dotToSvgHighQuality } from './generator/svg-generator';
 import { generateEditorHtml } from './generator/editor-html-generator';
 import { FileResolver } from './resolver/file-resolver';
 import { startWatch } from './watch';
+import { runMcpServer } from './mcp/server';
 
 const program = new Command();
 
@@ -42,7 +43,14 @@ program
   .option('--validate', 'Validate ALPS profile')
   .option('-w, --watch', 'Watch mode with live reload (requires Chrome with --remote-debugging-port=9222)')
   .option('--port <port>', 'CDP port for watch mode (default: 9222)', '9222')
+  .option('--mcp', 'Run as MCP server (stdio) for AI agents')
   .action(async (inputFile: string | undefined, options) => {
+    // MCP server mode (no input file required; tools take file paths)
+    if (options.mcp) {
+      await runMcpServer();
+      return;
+    }
+
     // Show help if no input file
     if (!inputFile) {
       console.log(`usage: asd [options] alps_file
@@ -55,6 +63,7 @@ Options:
   --port <port>           CDP port for watch mode (default: 9222)
   --label <mode>          Label mode: id or title
   --validate              Validate ALPS profile
+  --mcp                   Run as MCP server (stdio) for AI agents
   -v, --version           Show version information
   -h, --help              Show this help message
 

--- a/packages/cli/src/mcp/doc-store.ts
+++ b/packages/cli/src/mcp/doc-store.ts
@@ -1,0 +1,178 @@
+/**
+ * Doc store - descriptor documentation with automatic externalization
+ *
+ * Short docs are stored inline in the ALPS profile. When a doc is too large
+ * for inline use (long text, multi-line Markdown), it is written to
+ * `alps-doc/<descriptor-id>.md` next to the profile and linked from the
+ * descriptor via `doc.href`, keeping the profile compact while allowing
+ * rich documentation.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { AlpsDescriptor, AlpsDoc } from '../parser/alps-parser';
+
+export const DOC_DIR = 'alps-doc';
+
+/** Docs longer than this (or multi-line) are stored in an external file */
+export const INLINE_DOC_MAX_LENGTH = 200;
+
+export type DocPlacement = 'auto' | 'inline' | 'external';
+
+export interface SetDocResult {
+  id: string;
+  placement: 'inline' | 'external';
+  /** Path of the external doc file (relative to the profile), when external */
+  docFile?: string;
+  /** Previous external doc file left behind after switching to inline */
+  orphanedDocFile?: string;
+}
+
+/**
+ * Decide whether a doc should be stored in an external file
+ */
+export function shouldExternalize(doc: string): boolean {
+  return doc.length > INLINE_DOC_MAX_LENGTH || doc.includes('\n');
+}
+
+/**
+ * Set or update the doc of a descriptor in a JSON ALPS profile file.
+ *
+ * With placement 'auto', the doc is stored externally when it is large
+ * (see shouldExternalize) or when the descriptor already uses an external
+ * doc file under alps-doc/ (to avoid churn between inline and external).
+ */
+export function setDescriptorDoc(
+  profilePath: string,
+  id: string,
+  doc: string,
+  placement: DocPlacement = 'auto'
+): SetDocResult {
+  const absPath = path.resolve(profilePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${profilePath}`);
+  }
+
+  const content = fs.readFileSync(absPath, 'utf-8');
+  if (!content.trim().startsWith('{')) {
+    throw new Error(
+      'Writing docs is currently supported for JSON profiles only. ' +
+        'Convert the XML profile to JSON, or edit the XML directly.'
+    );
+  }
+
+  let root: any;
+  try {
+    root = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Invalid JSON format: ${(e as Error).message}`);
+  }
+
+  const descriptor = findDescriptorById(root?.alps?.descriptor, id);
+  if (!descriptor) {
+    throw new Error(`Descriptor not found: ${id}`);
+  }
+
+  const existingDoc: string | AlpsDoc | undefined = descriptor.doc;
+  const existingHref =
+    typeof existingDoc === 'object' && existingDoc?.href ? existingDoc.href : undefined;
+  const hasExternalDoc = existingHref !== undefined && isDocDirHref(existingHref);
+
+  let external: boolean;
+  if (placement === 'auto') {
+    external = hasExternalDoc || shouldExternalize(doc);
+  } else {
+    external = placement === 'external';
+  }
+
+  const baseDir = path.dirname(absPath);
+  const result: SetDocResult = { id, placement: external ? 'external' : 'inline' };
+
+  if (external) {
+    // Reuse the existing alps-doc file location when present
+    const docFile = hasExternalDoc ? existingHref! : `${DOC_DIR}/${safeFileName(id)}.md`;
+    const docFilePath = path.resolve(baseDir, docFile);
+    fs.mkdirSync(path.dirname(docFilePath), { recursive: true });
+    fs.writeFileSync(docFilePath, doc.endsWith('\n') ? doc : `${doc}\n`, 'utf-8');
+    descriptor.doc = { href: docFile, format: 'markdown' };
+    result.docFile = docFile;
+  } else {
+    if (hasExternalDoc) {
+      // The previous external file is kept; deleting user files silently is unsafe
+      result.orphanedDocFile = existingHref;
+    }
+    if (typeof existingDoc === 'object' && existingDoc !== null && !hasExternalDoc) {
+      // Preserve object form (and format) of an existing inline doc
+      const inlineDoc: AlpsDoc = { ...existingDoc, value: doc };
+      delete inlineDoc.href;
+      descriptor.doc = inlineDoc;
+    } else {
+      descriptor.doc = doc;
+    }
+  }
+
+  fs.writeFileSync(absPath, serializeLike(root, content), 'utf-8');
+  return result;
+}
+
+/**
+ * Resolve the doc of a descriptor, reading external alps-doc files
+ */
+export function resolveDoc(
+  baseDir: string,
+  doc: string | AlpsDoc | undefined
+): { text: string; href?: string; format?: string } | undefined {
+  if (doc === undefined || doc === null) {
+    return undefined;
+  }
+  if (typeof doc === 'string') {
+    return { text: doc };
+  }
+  if (doc.href && !/^https?:\/\//.test(doc.href)) {
+    const docPath = path.resolve(baseDir, doc.href);
+    if (fs.existsSync(docPath)) {
+      return { text: fs.readFileSync(docPath, 'utf-8'), href: doc.href, format: doc.format };
+    }
+    return { text: doc.value || '', href: doc.href, format: doc.format };
+  }
+  return { text: doc.value || '', href: doc.href, format: doc.format };
+}
+
+/**
+ * Find a descriptor by id, searching nested descriptors
+ */
+function findDescriptorById(descriptors: unknown, id: string): AlpsDescriptor | null {
+  if (!Array.isArray(descriptors)) {
+    return null;
+  }
+  for (const desc of descriptors) {
+    if (desc && typeof desc === 'object') {
+      if ((desc as AlpsDescriptor).id === id) {
+        return desc as AlpsDescriptor;
+      }
+      const found = findDescriptorById((desc as AlpsDescriptor).descriptor, id);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+function isDocDirHref(href: string): boolean {
+  return href.startsWith(`${DOC_DIR}/`) || href.startsWith(`./${DOC_DIR}/`);
+}
+
+function safeFileName(id: string): string {
+  return id.replace(/[^A-Za-z0-9._-]/g, '-');
+}
+
+/**
+ * Serialize JSON keeping the original file's indentation and trailing newline
+ */
+function serializeLike(root: unknown, original: string): string {
+  const indentMatch = original.match(/^([ \t]+)"/m);
+  const indent = indentMatch ? indentMatch[1] : '  ';
+  const json = JSON.stringify(root, null, indent);
+  return original.endsWith('\n') ? `${json}\n` : json;
+}

--- a/packages/cli/src/mcp/doc-store.ts
+++ b/packages/cli/src/mcp/doc-store.ts
@@ -98,7 +98,11 @@ export function setDescriptorDoc(
   if (external) {
     // Reuse the existing local doc file location when present
     const docFile = hasExternalDoc ? existingHref! : `${DOC_DIR}/${safeFileName(id)}.md`;
-    const docFilePath = resolveSafeLocalPath(baseDir, docFile)!;
+    const docFilePath = resolveSafeLocalPath(baseDir, docFile);
+    if (!docFilePath) {
+      // Reachable only when the default doc dir is a symlink escaping baseDir
+      throw new Error(`Unsafe doc path: ${docFile}`);
+    }
     fs.mkdirSync(path.dirname(docFilePath), { recursive: true });
     fs.writeFileSync(docFilePath, doc.endsWith('\n') ? doc : `${doc}\n`, 'utf-8');
     const format =
@@ -152,7 +156,9 @@ export function resolveDoc(
  * Resolve a doc href against the profile directory, rejecting anything
  * that escapes it: URL schemes ("http:", "file:", Windows drives),
  * protocol-relative or absolute paths, backslashes, and ../ traversal.
- * Returns the absolute path, or undefined when the href is unsafe.
+ * Symlinks inside the profile directory are legitimate (e.g. compat
+ * links keeping old layouts working), but their real targets must stay
+ * inside it. Returns the absolute path, or undefined when unsafe.
  */
 function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
@@ -164,6 +170,22 @@ function resolveSafeLocalPath(baseDir: string, href: string): string | undefined
   const abs = path.resolve(baseDir, href);
   const rel = path.relative(baseDir, abs);
   if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return undefined;
+  }
+  // Compare real paths so a symlinked component cannot escape baseDir.
+  // The target file may not exist yet (first write), so check the
+  // deepest existing ancestor instead.
+  try {
+    const baseReal = fs.realpathSync(baseDir);
+    let existing = abs;
+    while (!fs.existsSync(existing)) {
+      existing = path.dirname(existing);
+    }
+    const existingReal = fs.realpathSync(existing);
+    if (existingReal !== baseReal && !existingReal.startsWith(baseReal + path.sep)) {
+      return undefined;
+    }
+  } catch {
     return undefined;
   }
   return abs;

--- a/packages/cli/src/mcp/doc-store.ts
+++ b/packages/cli/src/mcp/doc-store.ts
@@ -3,9 +3,13 @@
  *
  * Short docs are stored inline in the ALPS profile. When a doc is too large
  * for inline use (long text, multi-line Markdown), it is written to
- * `alps-doc/<descriptor-id>.md` next to the profile and linked from the
+ * `alps/docs/<descriptor-id>.md` next to the profile and linked from the
  * descriptor via `doc.href`, keeping the profile compact while allowing
  * rich documentation.
+ *
+ * The `alps/` directory is the home for auxiliary design information:
+ * docs/ (descriptor documentation), rels/ (link relation definitions),
+ * links/ (compacted summaries of external link targets). See ADR 0003.
  */
 
 import * as fs from 'fs';
@@ -13,7 +17,7 @@ import * as path from 'path';
 import { findDescriptorById } from '../parser/alps-parser';
 import type { AlpsDoc } from '../parser/alps-parser';
 
-export const DOC_DIR = 'alps-doc';
+export const DOC_DIR = 'alps/docs';
 
 /** Docs longer than this (or multi-line) are stored in an external file */
 export const INLINE_DOC_MAX_LENGTH = 200;
@@ -123,7 +127,7 @@ export function setDescriptorDoc(
 }
 
 /**
- * Resolve the doc of a descriptor, reading external alps-doc files
+ * Resolve the doc of a descriptor, reading external doc files (e.g. alps/docs/)
  */
 export function resolveDoc(
   baseDir: string,
@@ -166,7 +170,7 @@ function resolveSafeLocalPath(baseDir: string, href: string): string | undefined
 }
 
 /**
- * Turn a descriptor id into a safe file name for alps-doc/
+ * Turn a descriptor id into a safe file name for alps/docs/
  */
 function safeFileName(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, '-');

--- a/packages/cli/src/mcp/doc-store.ts
+++ b/packages/cli/src/mcp/doc-store.ts
@@ -74,10 +74,13 @@ export function setDescriptorDoc(
     throw new Error(`Descriptor not found: ${id}`);
   }
 
+  const baseDir = path.dirname(absPath);
   const existingDoc: string | AlpsDoc | undefined = descriptor.doc;
   const existingHref =
     typeof existingDoc === 'object' && existingDoc?.href ? existingDoc.href : undefined;
-  const hasExternalDoc = existingHref !== undefined && isLocalHref(existingHref);
+  // Unsafe hrefs (absolute, ../ traversal, schemes) are never reused as write targets
+  const hasExternalDoc =
+    existingHref !== undefined && resolveSafeLocalPath(baseDir, existingHref) !== undefined;
 
   let external: boolean;
   if (placement === 'auto') {
@@ -86,13 +89,12 @@ export function setDescriptorDoc(
     external = placement === 'external';
   }
 
-  const baseDir = path.dirname(absPath);
   const result: SetDocResult = { id, placement: external ? 'external' : 'inline' };
 
   if (external) {
     // Reuse the existing local doc file location when present
     const docFile = hasExternalDoc ? existingHref! : `${DOC_DIR}/${safeFileName(id)}.md`;
-    const docFilePath = path.resolve(baseDir, docFile);
+    const docFilePath = resolveSafeLocalPath(baseDir, docFile)!;
     fs.mkdirSync(path.dirname(docFilePath), { recursive: true });
     fs.writeFileSync(docFilePath, doc.endsWith('\n') ? doc : `${doc}\n`, 'utf-8');
     const format =
@@ -133,20 +135,39 @@ export function resolveDoc(
   if (typeof doc === 'string') {
     return { text: doc };
   }
-  if (doc.href && isLocalHref(doc.href)) {
-    const docPath = path.resolve(baseDir, doc.href);
-    if (fs.existsSync(docPath)) {
+  if (doc.href) {
+    const docPath = resolveSafeLocalPath(baseDir, doc.href);
+    if (docPath && fs.existsSync(docPath)) {
       return { text: fs.readFileSync(docPath, 'utf-8'), href: doc.href, format: doc.format };
     }
-    return { text: doc.value || '', href: doc.href, format: doc.format };
   }
   return { text: doc.value || '', href: doc.href, format: doc.format };
 }
 
-function isLocalHref(href: string): boolean {
-  return !/^https?:\/\//.test(href);
+/**
+ * Resolve a doc href against the profile directory, rejecting anything
+ * that escapes it: URL schemes ("http:", "file:", Windows drives),
+ * protocol-relative or absolute paths, backslashes, and ../ traversal.
+ * Returns the absolute path, or undefined when the href is unsafe.
+ */
+function resolveSafeLocalPath(baseDir: string, href: string): string | undefined {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
+    return undefined;
+  }
+  if (href.startsWith('//') || href.includes('\\') || path.isAbsolute(href)) {
+    return undefined;
+  }
+  const abs = path.resolve(baseDir, href);
+  const rel = path.relative(baseDir, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return undefined;
+  }
+  return abs;
 }
 
+/**
+ * Turn a descriptor id into a safe file name for alps-doc/
+ */
 function safeFileName(id: string): string {
   return id.replace(/[^A-Za-z0-9._-]/g, '-');
 }

--- a/packages/cli/src/mcp/doc-store.ts
+++ b/packages/cli/src/mcp/doc-store.ts
@@ -10,7 +10,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { AlpsDescriptor, AlpsDoc } from '../parser/alps-parser';
+import { findDescriptorById } from '../parser/alps-parser';
+import type { AlpsDoc } from '../parser/alps-parser';
 
 export const DOC_DIR = 'alps-doc';
 
@@ -39,8 +40,8 @@ export function shouldExternalize(doc: string): boolean {
  * Set or update the doc of a descriptor in a JSON ALPS profile file.
  *
  * With placement 'auto', the doc is stored externally when it is large
- * (see shouldExternalize) or when the descriptor already uses an external
- * doc file under alps-doc/ (to avoid churn between inline and external).
+ * (see shouldExternalize) or when the descriptor already links a local
+ * doc file via doc.href (to avoid churn between inline and external).
  */
 export function setDescriptorDoc(
   profilePath: string,
@@ -76,7 +77,7 @@ export function setDescriptorDoc(
   const existingDoc: string | AlpsDoc | undefined = descriptor.doc;
   const existingHref =
     typeof existingDoc === 'object' && existingDoc?.href ? existingDoc.href : undefined;
-  const hasExternalDoc = existingHref !== undefined && isDocDirHref(existingHref);
+  const hasExternalDoc = existingHref !== undefined && isLocalHref(existingHref);
 
   let external: boolean;
   if (placement === 'auto') {
@@ -89,12 +90,16 @@ export function setDescriptorDoc(
   const result: SetDocResult = { id, placement: external ? 'external' : 'inline' };
 
   if (external) {
-    // Reuse the existing alps-doc file location when present
+    // Reuse the existing local doc file location when present
     const docFile = hasExternalDoc ? existingHref! : `${DOC_DIR}/${safeFileName(id)}.md`;
     const docFilePath = path.resolve(baseDir, docFile);
     fs.mkdirSync(path.dirname(docFilePath), { recursive: true });
     fs.writeFileSync(docFilePath, doc.endsWith('\n') ? doc : `${doc}\n`, 'utf-8');
-    descriptor.doc = { href: docFile, format: 'markdown' };
+    const format =
+      typeof existingDoc === 'object' && hasExternalDoc && existingDoc.format
+        ? existingDoc.format
+        : 'markdown';
+    descriptor.doc = { href: docFile, format };
     result.docFile = docFile;
   } else {
     if (hasExternalDoc) {
@@ -128,7 +133,7 @@ export function resolveDoc(
   if (typeof doc === 'string') {
     return { text: doc };
   }
-  if (doc.href && !/^https?:\/\//.test(doc.href)) {
+  if (doc.href && isLocalHref(doc.href)) {
     const docPath = path.resolve(baseDir, doc.href);
     if (fs.existsSync(docPath)) {
       return { text: fs.readFileSync(docPath, 'utf-8'), href: doc.href, format: doc.format };
@@ -138,29 +143,8 @@ export function resolveDoc(
   return { text: doc.value || '', href: doc.href, format: doc.format };
 }
 
-/**
- * Find a descriptor by id, searching nested descriptors
- */
-function findDescriptorById(descriptors: unknown, id: string): AlpsDescriptor | null {
-  if (!Array.isArray(descriptors)) {
-    return null;
-  }
-  for (const desc of descriptors) {
-    if (desc && typeof desc === 'object') {
-      if ((desc as AlpsDescriptor).id === id) {
-        return desc as AlpsDescriptor;
-      }
-      const found = findDescriptorById((desc as AlpsDescriptor).descriptor, id);
-      if (found) {
-        return found;
-      }
-    }
-  }
-  return null;
-}
-
-function isDocDirHref(href: string): boolean {
-  return href.startsWith(`${DOC_DIR}/`) || href.startsWith(`./${DOC_DIR}/`);
+function isLocalHref(href: string): boolean {
+  return !/^https?:\/\//.test(href);
 }
 
 function safeFileName(id: string): string {

--- a/packages/cli/src/mcp/graph.ts
+++ b/packages/cli/src/mcp/graph.ts
@@ -6,6 +6,7 @@
  * state/transition model as generator/dot-generator.ts.
  */
 
+import { localFragment } from '../parser/alps-parser';
 import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
 
 export type TransitionType = 'safe' | 'unsafe' | 'idempotent';
@@ -33,6 +34,9 @@ export interface PathStep {
 
 const TRANSITION_TYPES = new Set(['safe', 'unsafe', 'idempotent']);
 
+/**
+ * Whether a descriptor is a state transition (safe/unsafe/idempotent with rt)
+ */
 export function isTransition(descriptor: AlpsDescriptor): boolean {
   return !!descriptor.type && TRANSITION_TYPES.has(descriptor.type) && !!descriptor.rt;
 }
@@ -45,13 +49,15 @@ export function extractGraph(alpsData: AlpsDocument): StateGraph {
 
   const transitions: TransitionInfo[] = [];
   for (const desc of descriptors) {
-    if (desc.id && isTransition(desc)) {
+    // External rt references (e.g. "other.json#State") are not part of this graph
+    const rtTarget = localFragment(desc.rt);
+    if (desc.id && isTransition(desc) && rtTarget) {
       transitions.push({
         id: desc.id,
         type: desc.type as TransitionType,
         title: desc.title,
         from: findContainers(desc.id, descriptors),
-        to: desc.rt!.replace(/^#/, ''),
+        to: rtTarget,
       });
     }
   }

--- a/packages/cli/src/mcp/graph.ts
+++ b/packages/cli/src/mcp/graph.ts
@@ -1,0 +1,149 @@
+/**
+ * Graph utilities for ALPS state diagrams
+ *
+ * Extracts the application state graph (states and transitions) from an
+ * ALPS document and answers reachability questions over it. Uses the same
+ * state/transition model as generator/dot-generator.ts.
+ */
+
+import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+
+export type TransitionType = 'safe' | 'unsafe' | 'idempotent';
+
+export interface TransitionInfo {
+  id: string;
+  type: TransitionType;
+  title?: string;
+  /** States containing this transition */
+  from: string[];
+  /** Target state (rt) */
+  to: string;
+}
+
+export interface StateGraph {
+  states: AlpsDescriptor[];
+  transitions: TransitionInfo[];
+}
+
+export interface PathStep {
+  transition: string;
+  type: TransitionType;
+  to: string;
+}
+
+const TRANSITION_TYPES = new Set(['safe', 'unsafe', 'idempotent']);
+
+export function isTransition(descriptor: AlpsDescriptor): boolean {
+  return !!descriptor.type && TRANSITION_TYPES.has(descriptor.type) && !!descriptor.rt;
+}
+
+/**
+ * Extract the state graph from an ALPS document
+ */
+export function extractGraph(alpsData: AlpsDocument): StateGraph {
+  const descriptors = alpsData.alps?.descriptor || [];
+
+  const transitions: TransitionInfo[] = [];
+  for (const desc of descriptors) {
+    if (desc.id && isTransition(desc)) {
+      transitions.push({
+        id: desc.id,
+        type: desc.type as TransitionType,
+        title: desc.title,
+        from: findContainers(desc.id, descriptors),
+        to: desc.rt!.replace(/^#/, ''),
+      });
+    }
+  }
+
+  const stateIds = new Set<string>();
+  for (const trans of transitions) {
+    stateIds.add(trans.to);
+    for (const from of trans.from) {
+      stateIds.add(from);
+    }
+  }
+  const states = descriptors.filter(d => d.id && stateIds.has(d.id));
+
+  return { states, transitions };
+}
+
+/**
+ * Find descriptors that contain the given descriptor (by href or inline id)
+ */
+export function findContainers(childId: string, descriptors: AlpsDescriptor[]): string[] {
+  const containers: string[] = [];
+  for (const desc of descriptors) {
+    if (desc.id && Array.isArray(desc.descriptor)) {
+      const contains = desc.descriptor.some(
+        nested => nested.href === `#${childId}` || nested.id === childId
+      );
+      if (contains) {
+        containers.push(desc.id);
+      }
+    }
+  }
+  return containers;
+}
+
+/**
+ * Enumerate paths between two states (DFS, no state revisited within a path)
+ */
+export function findPaths(
+  graph: StateGraph,
+  from: string,
+  to: string,
+  maxPaths = 10,
+  maxDepth = 10
+): PathStep[][] {
+  const edgesFrom = new Map<string, TransitionInfo[]>();
+  for (const trans of graph.transitions) {
+    for (const source of trans.from) {
+      if (!edgesFrom.has(source)) {
+        edgesFrom.set(source, []);
+      }
+      edgesFrom.get(source)!.push(trans);
+    }
+  }
+
+  const paths: PathStep[][] = [];
+  const visited = new Set<string>([from]);
+  const current: PathStep[] = [];
+
+  const dfs = (state: string): void => {
+    if (paths.length >= maxPaths || current.length >= maxDepth) {
+      return;
+    }
+    for (const trans of edgesFrom.get(state) || []) {
+      if (visited.has(trans.to)) {
+        continue;
+      }
+      current.push({ transition: trans.id, type: trans.type, to: trans.to });
+      if (trans.to === to) {
+        paths.push([...current]);
+      } else {
+        visited.add(trans.to);
+        dfs(trans.to);
+        visited.delete(trans.to);
+      }
+      current.pop();
+      if (paths.length >= maxPaths) {
+        return;
+      }
+    }
+  };
+
+  dfs(from);
+  return paths;
+}
+
+/**
+ * Format a path as a readable string: Home --goToCart(safe)--> ShoppingCart
+ */
+export function formatPath(from: string, path: PathStep[]): string {
+  let result = from;
+  for (const step of path) {
+    result += ` --${step.transition}(${step.type})--> ${step.to}`;
+  }
+  return result;
+}

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -7,7 +7,7 @@
  * transitions, enumerate paths) and update descriptor documentation.
  *
  * Large docs are automatically stored in external Markdown files under
- * alps-doc/ and linked via doc.href (see doc-store.ts).
+ * alps/docs/ and linked via doc.href (see doc-store.ts).
  */
 
 import * as fs from 'fs';
@@ -246,7 +246,7 @@ export function createServer(): McpServer {
       title: 'Get descriptor details',
       description:
         'Get full details of one descriptor: definition, resolved documentation ' +
-        '(external alps-doc files are read and inlined), containing states, and ' +
+        '(external alps/ doc files are read and inlined), containing states, and ' +
         'incoming/outgoing transitions.',
       inputSchema: {
         file: fileParam,
@@ -351,7 +351,7 @@ export function createServer(): McpServer {
         'Set or update the documentation of a descriptor in a JSON ALPS profile. ' +
         `Short single-line docs (<= ${INLINE_DOC_MAX_LENGTH} chars) are stored inline; ` +
         'longer or multi-line docs are automatically written to an external Markdown ' +
-        'file (alps-doc/<id>.md) and linked from the profile via doc.href. This keeps ' +
+        'file (alps/docs/<id>.md) and linked from the profile via doc.href. This keeps ' +
         'the profile compact, so feel free to write rich, detailed Markdown ' +
         'documentation describing the meaning of the state and related information.',
       inputSchema: {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -34,6 +34,10 @@ interface LoadedProfile {
   absPath: string;
 }
 
+/**
+ * Read, parse, and resolve an ALPS profile from disk.
+ * Always reads fresh so edits between tool calls are visible.
+ */
 async function loadProfile(file: string): Promise<LoadedProfile> {
   const absPath = path.resolve(file);
   if (!fs.existsSync(absPath)) {
@@ -47,10 +51,16 @@ async function loadProfile(file: string): Promise<LoadedProfile> {
   return { document, baseDir, absPath };
 }
 
+/**
+ * Split the space-separated tag attribute into a list
+ */
 function descriptorTags(desc: AlpsDescriptor): string[] {
   return (desc.tag || '').split(/\s+/).filter(Boolean);
 }
 
+/**
+ * Short doc excerpt for search results; external docs show their href
+ */
 function docPreview(desc: AlpsDescriptor): string | undefined {
   const text = docText(desc.doc);
   if (!text) {
@@ -60,6 +70,9 @@ function docPreview(desc: AlpsDescriptor): string | undefined {
   return text.length > DOC_PREVIEW_LENGTH ? `${text.slice(0, DOC_PREVIEW_LENGTH)}…` : text;
 }
 
+/**
+ * Compact descriptor summary returned by alps_search
+ */
 function summarize(desc: AlpsDescriptor) {
   const tags = descriptorTags(desc);
   const doc = docPreview(desc);
@@ -82,14 +95,23 @@ function allDescriptors(document: AlpsDocument): AlpsDescriptor[] {
   return result;
 }
 
+/**
+ * MCP tool result with pretty-printed JSON content
+ */
 function jsonResult(data: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
 }
 
+/**
+ * MCP tool result with plain text content
+ */
 function textResult(text: string) {
   return { content: [{ type: 'text' as const, text }] };
 }
 
+/**
+ * MCP tool error result
+ */
 function errorResult(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
@@ -97,6 +119,9 @@ function errorResult(error: unknown) {
 
 const fileParam = z.string().describe('Path to the ALPS profile file (JSON or XML)');
 
+/**
+ * Create the MCP server with all ALPS tools registered
+ */
 export function createServer(): McpServer {
   const server = new McpServer({ name: 'alps-asd', version: SERVER_VERSION });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { parseAlpsAuto, docText } from '../parser/alps-parser';
+import { parseAlpsAuto, docText, findDescriptorById, walkDescriptors } from '../parser/alps-parser';
 import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
 import { FileResolver } from '../resolver/file-resolver';
 import { generateDot } from '../generator/dot-generator';
@@ -24,7 +24,8 @@ import { extractGraph, findPaths, formatPath, findContainers } from './graph';
 import { validateAlps } from './validator';
 import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from './doc-store';
 
-const SERVER_VERSION = '0.20.0';
+// Version is read from package.json so releases bump it in one place
+const SERVER_VERSION: string = require('../../package.json').version;
 const DOC_PREVIEW_LENGTH = 80;
 
 interface LoadedProfile {
@@ -60,14 +61,25 @@ function docPreview(desc: AlpsDescriptor): string | undefined {
 }
 
 function summarize(desc: AlpsDescriptor) {
+  const tags = descriptorTags(desc);
+  const doc = docPreview(desc);
   return {
     id: desc.id,
     type: desc.type || 'semantic',
     title: desc.title,
     ...(desc.rt ? { rt: desc.rt } : {}),
-    ...(descriptorTags(desc).length ? { tags: descriptorTags(desc) } : {}),
-    ...(docPreview(desc) ? { doc: docPreview(desc) } : {}),
+    ...(tags.length ? { tags } : {}),
+    ...(doc ? { doc } : {}),
   };
+}
+
+/**
+ * Collect all descriptors (top-level and nested) in document order
+ */
+function allDescriptors(document: AlpsDocument): AlpsDescriptor[] {
+  const result: AlpsDescriptor[] = [];
+  walkDescriptors(document.alps.descriptor || [], desc => result.push(desc));
+  return result;
 }
 
 function jsonResult(data: unknown) {
@@ -101,7 +113,7 @@ export function createServer(): McpServer {
     async ({ file }) => {
       try {
         const { document } = await loadProfile(file);
-        const descriptors = document.alps.descriptor || [];
+        const descriptors = allDescriptors(document);
         const graph = extractGraph(document);
         const tags = new Set<string>();
         for (const desc of descriptors) {
@@ -176,7 +188,7 @@ export function createServer(): McpServer {
     async ({ file, type, tag, text }) => {
       try {
         const { document } = await loadProfile(file);
-        const descriptors = document.alps.descriptor || [];
+        const descriptors = allDescriptors(document);
         const needle = text?.toLowerCase();
         const matches = descriptors.filter(desc => {
           if (!desc.id) {
@@ -220,7 +232,7 @@ export function createServer(): McpServer {
       try {
         const { document, baseDir } = await loadProfile(file);
         const descriptors = document.alps.descriptor || [];
-        const descriptor = descriptors.find(d => d.id === id) || findNested(descriptors, id);
+        const descriptor = findDescriptorById(descriptors, id);
         if (!descriptor) {
           throw new Error(`Descriptor not found: ${id}`);
         }
@@ -338,21 +350,6 @@ export function createServer(): McpServer {
   );
 
   return server;
-}
-
-function findNested(descriptors: AlpsDescriptor[], id: string): AlpsDescriptor | undefined {
-  for (const desc of descriptors) {
-    if (desc.id === id) {
-      return desc;
-    }
-    if (Array.isArray(desc.descriptor)) {
-      const found = findNested(desc.descriptor, id);
-      if (found) {
-        return found;
-      }
-    }
-  }
-  return undefined;
 }
 
 /**

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1,0 +1,367 @@
+/**
+ * ALPS MCP server
+ *
+ * Exposes ALPS profiles to AI agents over the Model Context Protocol
+ * (stdio). Unlike the one-shot CLI, the MCP tools let an agent query the
+ * application state model incrementally (filter descriptors, follow
+ * transitions, enumerate paths) and update descriptor documentation.
+ *
+ * Large docs are automatically stored in external Markdown files under
+ * alps-doc/ and linked via doc.href (see doc-store.ts).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { parseAlpsAuto, docText } from '../parser/alps-parser';
+import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+import { FileResolver } from '../resolver/file-resolver';
+import { generateDot } from '../generator/dot-generator';
+import { dotToSvgHighQuality } from '../generator/svg-generator';
+import { extractGraph, findPaths, formatPath, findContainers } from './graph';
+import { validateAlps } from './validator';
+import { setDescriptorDoc, resolveDoc, INLINE_DOC_MAX_LENGTH } from './doc-store';
+
+const SERVER_VERSION = '0.20.0';
+const DOC_PREVIEW_LENGTH = 80;
+
+interface LoadedProfile {
+  document: AlpsDocument;
+  baseDir: string;
+  absPath: string;
+}
+
+async function loadProfile(file: string): Promise<LoadedProfile> {
+  const absPath = path.resolve(file);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Profile file not found: ${file}`);
+  }
+  const content = fs.readFileSync(absPath, 'utf-8');
+  const baseDir = path.dirname(absPath);
+  const parsed = parseAlpsAuto(content);
+  const resolver = new FileResolver(baseDir);
+  const document = await resolver.resolve(parsed);
+  return { document, baseDir, absPath };
+}
+
+function descriptorTags(desc: AlpsDescriptor): string[] {
+  return (desc.tag || '').split(/\s+/).filter(Boolean);
+}
+
+function docPreview(desc: AlpsDescriptor): string | undefined {
+  const text = docText(desc.doc);
+  if (!text) {
+    const href = typeof desc.doc === 'object' ? desc.doc?.href : undefined;
+    return href ? `(external: ${href})` : undefined;
+  }
+  return text.length > DOC_PREVIEW_LENGTH ? `${text.slice(0, DOC_PREVIEW_LENGTH)}…` : text;
+}
+
+function summarize(desc: AlpsDescriptor) {
+  return {
+    id: desc.id,
+    type: desc.type || 'semantic',
+    title: desc.title,
+    ...(desc.rt ? { rt: desc.rt } : {}),
+    ...(descriptorTags(desc).length ? { tags: descriptorTags(desc) } : {}),
+    ...(docPreview(desc) ? { doc: docPreview(desc) } : {}),
+  };
+}
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+function textResult(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function errorResult(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+}
+
+const fileParam = z.string().describe('Path to the ALPS profile file (JSON or XML)');
+
+export function createServer(): McpServer {
+  const server = new McpServer({ name: 'alps-asd', version: SERVER_VERSION });
+
+  server.registerTool(
+    'alps_overview',
+    {
+      title: 'ALPS profile overview',
+      description:
+        'Summarize an ALPS profile: title, application states, transitions ' +
+        '(with from/to states), and tags. Use this first to understand the ' +
+        'application state model.',
+      inputSchema: { file: fileParam },
+    },
+    async ({ file }) => {
+      try {
+        const { document } = await loadProfile(file);
+        const descriptors = document.alps.descriptor || [];
+        const graph = extractGraph(document);
+        const tags = new Set<string>();
+        for (const desc of descriptors) {
+          descriptorTags(desc).forEach(tag => tags.add(tag));
+        }
+        return jsonResult({
+          title: document.alps.title,
+          doc: docText(document.alps.doc) || undefined,
+          counts: {
+            descriptors: descriptors.length,
+            states: graph.states.length,
+            transitions: graph.transitions.length,
+          },
+          states: graph.states.map(s => ({ id: s.id, title: s.title })),
+          transitions: graph.transitions.map(t => ({
+            id: t.id,
+            type: t.type,
+            from: t.from,
+            to: t.to,
+          })),
+          tags: [...tags].sort(),
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    'alps_validate',
+    {
+      title: 'Validate ALPS profile',
+      description:
+        'Validate an ALPS profile. Reports errors (broken references, duplicate ' +
+        'ids, missing rt) and warnings (naming conventions, orphan descriptors).',
+      inputSchema: { file: fileParam },
+    },
+    async ({ file }) => {
+      try {
+        const absPath = path.resolve(file);
+        if (!fs.existsSync(absPath)) {
+          throw new Error(`Profile file not found: ${file}`);
+        }
+        const document = parseAlpsAuto(fs.readFileSync(absPath, 'utf-8'));
+        return jsonResult(validateAlps(document));
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    'alps_search',
+    {
+      title: 'Search descriptors',
+      description:
+        'Filter descriptors in an ALPS profile by type, tag, and/or free text ' +
+        '(matched against id, title, and doc). Returns compact summaries.',
+      inputSchema: {
+        file: fileParam,
+        type: z
+          .enum(['semantic', 'safe', 'unsafe', 'idempotent'])
+          .optional()
+          .describe('Filter by descriptor type'),
+        tag: z.string().optional().describe('Filter by tag'),
+        text: z
+          .string()
+          .optional()
+          .describe('Case-insensitive text search in id, title, and doc'),
+      },
+    },
+    async ({ file, type, tag, text }) => {
+      try {
+        const { document } = await loadProfile(file);
+        const descriptors = document.alps.descriptor || [];
+        const needle = text?.toLowerCase();
+        const matches = descriptors.filter(desc => {
+          if (!desc.id) {
+            return false;
+          }
+          if (type && (desc.type || 'semantic') !== type) {
+            return false;
+          }
+          if (tag && !descriptorTags(desc).includes(tag)) {
+            return false;
+          }
+          if (needle) {
+            const haystack = `${desc.id} ${desc.title || ''} ${docText(desc.doc)}`.toLowerCase();
+            if (!haystack.includes(needle)) {
+              return false;
+            }
+          }
+          return true;
+        });
+        return jsonResult({ count: matches.length, descriptors: matches.map(summarize) });
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    'alps_descriptor',
+    {
+      title: 'Get descriptor details',
+      description:
+        'Get full details of one descriptor: definition, resolved documentation ' +
+        '(external alps-doc files are read and inlined), containing states, and ' +
+        'incoming/outgoing transitions.',
+      inputSchema: {
+        file: fileParam,
+        id: z.string().describe('Descriptor id'),
+      },
+    },
+    async ({ file, id }) => {
+      try {
+        const { document, baseDir } = await loadProfile(file);
+        const descriptors = document.alps.descriptor || [];
+        const descriptor = descriptors.find(d => d.id === id) || findNested(descriptors, id);
+        if (!descriptor) {
+          throw new Error(`Descriptor not found: ${id}`);
+        }
+        const graph = extractGraph(document);
+        return jsonResult({
+          descriptor,
+          doc: resolveDoc(baseDir, descriptor.doc),
+          containedBy: findContainers(id, descriptors),
+          outgoingTransitions: graph.transitions
+            .filter(t => t.from.includes(id))
+            .map(t => ({ id: t.id, type: t.type, to: t.to })),
+          incomingTransitions: graph.transitions
+            .filter(t => t.to === id)
+            .map(t => ({ id: t.id, type: t.type, from: t.from })),
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    'alps_paths',
+    {
+      title: 'Find paths between states',
+      description:
+        'Enumerate transition paths from one application state to another, ' +
+        'e.g. all ways a user can get from Home to OrderConfirmation.',
+      inputSchema: {
+        file: fileParam,
+        from: z.string().describe('Starting state id'),
+        to: z.string().describe('Target state id'),
+        maxPaths: z.number().int().min(1).max(50).optional().describe('Maximum paths (default 10)'),
+      },
+    },
+    async ({ file, from, to, maxPaths }) => {
+      try {
+        const { document } = await loadProfile(file);
+        const graph = extractGraph(document);
+        const stateIds = new Set(graph.states.map(s => s.id));
+        for (const state of [from, to]) {
+          if (!stateIds.has(state)) {
+            throw new Error(
+              `Unknown state: ${state} (known states: ${[...stateIds].join(', ')})`
+            );
+          }
+        }
+        const paths = findPaths(graph, from, to, maxPaths ?? 10);
+        return jsonResult({
+          from,
+          to,
+          count: paths.length,
+          paths: paths.map(p => formatPath(from, p)),
+        });
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    'alps_diagram',
+    {
+      title: 'Render state diagram',
+      description: 'Render the application state diagram as Graphviz DOT or SVG.',
+      inputSchema: {
+        file: fileParam,
+        format: z.enum(['dot', 'svg']).optional().describe('Output format (default: dot)'),
+        label: z.enum(['id', 'title']).optional().describe('Node label mode (default: id)'),
+      },
+    },
+    async ({ file, format, label }) => {
+      try {
+        const { document } = await loadProfile(file);
+        const dot = generateDot(document, label === 'title' ? 'title' : 'id');
+        if (format === 'svg') {
+          return textResult(await dotToSvgHighQuality(dot));
+        }
+        return textResult(dot);
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    'alps_set_doc',
+    {
+      title: 'Set descriptor documentation',
+      description:
+        'Set or update the documentation of a descriptor in a JSON ALPS profile. ' +
+        `Short single-line docs (<= ${INLINE_DOC_MAX_LENGTH} chars) are stored inline; ` +
+        'longer or multi-line docs are automatically written to an external Markdown ' +
+        'file (alps-doc/<id>.md) and linked from the profile via doc.href. This keeps ' +
+        'the profile compact, so feel free to write rich, detailed Markdown ' +
+        'documentation describing the meaning of the state and related information.',
+      inputSchema: {
+        file: fileParam,
+        id: z.string().describe('Descriptor id'),
+        doc: z.string().describe('Documentation text (Markdown welcome for external docs)'),
+        placement: z
+          .enum(['auto', 'inline', 'external'])
+          .optional()
+          .describe('Storage placement (default: auto - the server decides by size)'),
+      },
+    },
+    async ({ file, id, doc, placement }) => {
+      try {
+        const result = setDescriptorDoc(file, id, doc, placement ?? 'auto');
+        return jsonResult(result);
+      } catch (error) {
+        return errorResult(error);
+      }
+    }
+  );
+
+  return server;
+}
+
+function findNested(descriptors: AlpsDescriptor[], id: string): AlpsDescriptor | undefined {
+  for (const desc of descriptors) {
+    if (desc.id === id) {
+      return desc;
+    }
+    if (Array.isArray(desc.descriptor)) {
+      const found = findNested(desc.descriptor, id);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Start the MCP server on stdio
+ */
+export async function runMcpServer(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // Keep the process alive; the transport closes stdin on client disconnect
+  console.error('ALPS MCP server running on stdio');
+}

--- a/packages/cli/src/mcp/validator.ts
+++ b/packages/cli/src/mcp/validator.ts
@@ -1,0 +1,175 @@
+/**
+ * ALPS profile validation
+ *
+ * Structural and semantic checks over a parsed ALPS document. Error and
+ * warning codes follow the conventions documented in the README
+ * (E001-E011, W001-W004).
+ */
+
+import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+
+export interface ValidationIssue {
+  code: string;
+  severity: 'error' | 'warning';
+  message: string;
+  descriptorId?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+}
+
+const VALID_TYPES = new Set(['semantic', 'safe', 'unsafe', 'idempotent']);
+const TRANSITION_TYPES = new Set(['safe', 'unsafe', 'idempotent']);
+
+/**
+ * Validate an ALPS document
+ */
+export function validateAlps(document: AlpsDocument): ValidationResult {
+  const errors: ValidationIssue[] = [];
+  const warnings: ValidationIssue[] = [];
+
+  if (!document || !document.alps) {
+    errors.push({ code: 'E008', severity: 'error', message: 'Missing alps property' });
+    return { valid: false, errors, warnings };
+  }
+
+  const descriptors = document.alps.descriptor;
+  if (!descriptors || !Array.isArray(descriptors) || descriptors.length === 0) {
+    errors.push({ code: 'E009', severity: 'error', message: 'Missing descriptor array' });
+    return { valid: false, errors, warnings };
+  }
+
+  const allIds = new Set<string>();
+  const referencedIds = new Set<string>();
+  const seenIds = new Set<string>();
+
+  // First pass: collect ids and references
+  walkDescriptors(descriptors, desc => {
+    if (desc.id) {
+      if (seenIds.has(desc.id)) {
+        errors.push({
+          code: 'E005',
+          severity: 'error',
+          message: `Duplicate id: ${desc.id}`,
+          descriptorId: desc.id,
+        });
+      }
+      seenIds.add(desc.id);
+      allIds.add(desc.id);
+    }
+    const href = localFragment(desc.href);
+    if (href) {
+      referencedIds.add(href);
+    }
+    const rt = localFragment(desc.rt);
+    if (rt) {
+      referencedIds.add(rt);
+    }
+  });
+
+  // Second pass: per-descriptor checks
+  walkDescriptors(descriptors, desc => {
+    if (!desc.id && !desc.href) {
+      errors.push({ code: 'E001', severity: 'error', message: 'Descriptor missing id or href' });
+      return;
+    }
+
+    if (desc.type && !VALID_TYPES.has(desc.type)) {
+      errors.push({
+        code: 'E003',
+        severity: 'error',
+        message: `Invalid type "${desc.type}"`,
+        descriptorId: desc.id,
+      });
+    }
+
+    const isTransitionType = !!desc.type && TRANSITION_TYPES.has(desc.type);
+    if (isTransitionType && desc.id && !desc.rt) {
+      errors.push({
+        code: 'E002',
+        severity: 'error',
+        message: `Transition "${desc.id}" is missing rt (return type)`,
+        descriptorId: desc.id,
+      });
+    }
+
+    const rt = localFragment(desc.rt);
+    if (rt && !allIds.has(rt)) {
+      errors.push({
+        code: 'E004',
+        severity: 'error',
+        message: `Broken reference: rt "#${rt}" points to non-existent id`,
+        descriptorId: desc.id,
+      });
+    }
+    const href = localFragment(desc.href);
+    if (href && !allIds.has(href)) {
+      errors.push({
+        code: 'E004',
+        severity: 'error',
+        message: `Broken reference: href "#${href}" points to non-existent id`,
+        descriptorId: desc.id,
+      });
+    }
+
+    if (desc.id && desc.type === 'safe' && !desc.id.startsWith('go')) {
+      warnings.push({
+        code: 'W002',
+        severity: 'warning',
+        message: `Safe transition "${desc.id}" should start with "go"`,
+        descriptorId: desc.id,
+      });
+    }
+    if (
+      desc.id &&
+      (desc.type === 'unsafe' || desc.type === 'idempotent') &&
+      !desc.id.startsWith('do')
+    ) {
+      warnings.push({
+        code: 'W003',
+        severity: 'warning',
+        message: `${desc.type} transition "${desc.id}" should start with "do"`,
+        descriptorId: desc.id,
+      });
+    }
+  });
+
+  // Orphan check: top-level descriptors never referenced anywhere
+  for (const desc of descriptors) {
+    if (desc.id && !referencedIds.has(desc.id)) {
+      warnings.push({
+        code: 'W004',
+        severity: 'warning',
+        message: `Orphan descriptor "${desc.id}" is defined but never referenced`,
+        descriptorId: desc.id,
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Extract a local fragment id from href/rt ("#id" or "file.json#id" -> null for external)
+ */
+function localFragment(ref: string | undefined): string | null {
+  if (!ref || !ref.startsWith('#')) {
+    return null;
+  }
+  return ref.substring(1);
+}
+
+function walkDescriptors(
+  descriptors: AlpsDescriptor[],
+  visit: (desc: AlpsDescriptor) => void
+): void {
+  for (const desc of descriptors) {
+    visit(desc);
+    if (Array.isArray(desc.descriptor)) {
+      walkDescriptors(desc.descriptor, visit);
+    }
+  }
+}

--- a/packages/cli/src/mcp/validator.ts
+++ b/packages/cli/src/mcp/validator.ts
@@ -6,7 +6,8 @@
  * (E001-E011, W001-W004).
  */
 
-import type { AlpsDocument, AlpsDescriptor } from '../parser/alps-parser';
+import { walkDescriptors } from '../parser/alps-parser';
+import type { AlpsDocument } from '../parser/alps-parser';
 
 export interface ValidationIssue {
   code: string;
@@ -160,16 +161,4 @@ function localFragment(ref: string | undefined): string | null {
     return null;
   }
   return ref.substring(1);
-}
-
-function walkDescriptors(
-  descriptors: AlpsDescriptor[],
-  visit: (desc: AlpsDescriptor) => void
-): void {
-  for (const desc of descriptors) {
-    visit(desc);
-    if (Array.isArray(desc.descriptor)) {
-      walkDescriptors(desc.descriptor, visit);
-    }
-  }
 }

--- a/packages/cli/src/mcp/validator.ts
+++ b/packages/cli/src/mcp/validator.ts
@@ -6,7 +6,7 @@
  * (E001-E011, W001-W004).
  */
 
-import { walkDescriptors } from '../parser/alps-parser';
+import { walkDescriptors, localFragment } from '../parser/alps-parser';
 import type { AlpsDocument } from '../parser/alps-parser';
 
 export interface ValidationIssue {
@@ -151,14 +151,4 @@ export function validateAlps(document: AlpsDocument): ValidationResult {
   }
 
   return { valid: errors.length === 0, errors, warnings };
-}
-
-/**
- * Extract a local fragment id from href/rt ("#id" or "file.json#id" -> null for external)
- */
-function localFragment(ref: string | undefined): string | null {
-  if (!ref || !ref.startsWith('#')) {
-    return null;
-  }
-  return ref.substring(1);
 }

--- a/packages/cli/src/parser/alps-parser.ts
+++ b/packages/cli/src/parser/alps-parser.ts
@@ -176,6 +176,43 @@ export function docText(doc: string | AlpsDoc | undefined): string {
 }
 
 /**
+ * Visit every descriptor in a tree, depth-first
+ */
+export function walkDescriptors(
+  descriptors: AlpsDescriptor[],
+  visit: (desc: AlpsDescriptor) => void
+): void {
+  for (const desc of descriptors) {
+    visit(desc);
+    if (Array.isArray(desc.descriptor)) {
+      walkDescriptors(desc.descriptor, visit);
+    }
+  }
+}
+
+/**
+ * Find a descriptor by id, searching nested descriptors.
+ * Accepts unknown input so it can be used on raw (unnormalized) JSON.
+ */
+export function findDescriptorById(descriptors: unknown, id: string): AlpsDescriptor | null {
+  if (!Array.isArray(descriptors)) {
+    return null;
+  }
+  for (const desc of descriptors) {
+    if (desc && typeof desc === 'object') {
+      if ((desc as AlpsDescriptor).id === id) {
+        return desc as AlpsDescriptor;
+      }
+      const found = findDescriptorById((desc as AlpsDescriptor).descriptor, id);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Convert XML descriptor to AlpsDescriptor
  */
 function convertDescriptor(desc: any): AlpsDescriptor {

--- a/packages/cli/src/parser/alps-parser.ts
+++ b/packages/cli/src/parser/alps-parser.ts
@@ -123,10 +123,14 @@ function xmlToAlpsObject(parsed: any): AlpsDocument {
   const result: AlpsDocument = {
     alps: {
       title: alps.title?.['#text'] || alps.title || 'ALPS Profile',
-      doc: convertDoc(alps.doc) || '',
       descriptor: descriptors,
     },
   };
+
+  const rootDoc = convertDoc(alps.doc);
+  if (rootDoc !== undefined) {
+    result.alps.doc = rootDoc;
+  }
 
   if (links.length > 0) {
     result.alps.link = links;
@@ -173,6 +177,17 @@ export function docText(doc: string | AlpsDoc | undefined): string {
     return doc;
   }
   return doc.value || '';
+}
+
+/**
+ * Extract a local fragment id from an href/rt reference.
+ * Returns null for external references ("file.json#id", "http://...").
+ */
+export function localFragment(ref: string | undefined): string | null {
+  if (!ref || !ref.startsWith('#')) {
+    return null;
+  }
+  return ref.substring(1);
 }
 
 /**

--- a/packages/cli/src/parser/alps-parser.ts
+++ b/packages/cli/src/parser/alps-parser.ts
@@ -7,12 +7,19 @@
 
 import { XMLParser } from 'fast-xml-parser';
 
+export interface AlpsDoc {
+  value?: string;
+  href?: string;
+  format?: string;
+  contentType?: string;
+}
+
 export interface AlpsDescriptor {
   id?: string;
   type?: 'semantic' | 'safe' | 'unsafe' | 'idempotent';
   title?: string;
   def?: string;
-  doc?: string | { value: string };
+  doc?: string | AlpsDoc;
   rel?: string;
   rt?: string;
   tag?: string;
@@ -29,7 +36,7 @@ export interface AlpsLink {
 export interface AlpsDocument {
   alps: {
     title?: string;
-    doc?: string | { value: string };
+    doc?: string | AlpsDoc;
     descriptor?: AlpsDescriptor[];
     link?: AlpsLink | AlpsLink[];
   };
@@ -116,7 +123,7 @@ function xmlToAlpsObject(parsed: any): AlpsDocument {
   const result: AlpsDocument = {
     alps: {
       title: alps.title?.['#text'] || alps.title || 'ALPS Profile',
-      doc: alps.doc?.['#text'] || alps.doc || '',
+      doc: convertDoc(alps.doc) || '',
       descriptor: descriptors,
     },
   };
@@ -126,6 +133,46 @@ function xmlToAlpsObject(parsed: any): AlpsDocument {
   }
 
   return result;
+}
+
+/**
+ * Convert XML doc element to string or AlpsDoc.
+ * Supports <doc>text</doc> and <doc href="..." format="..."/> forms.
+ */
+function convertDoc(doc: any): string | AlpsDoc | undefined {
+  if (doc === undefined || doc === null) {
+    return undefined;
+  }
+  if (typeof doc === 'string') {
+    return doc;
+  }
+  const result: AlpsDoc = {};
+  if (doc['#text'] !== undefined) {
+    result.value = String(doc['#text']);
+  }
+  if (doc['@_href']) {
+    result.href = doc['@_href'];
+  }
+  if (doc['@_format']) {
+    result.format = doc['@_format'];
+  }
+  if (doc['@_contentType']) {
+    result.contentType = doc['@_contentType'];
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Get the inline text of a doc (string or AlpsDoc form)
+ */
+export function docText(doc: string | AlpsDoc | undefined): string {
+  if (doc === undefined) {
+    return '';
+  }
+  if (typeof doc === 'string') {
+    return doc;
+  }
+  return doc.value || '';
 }
 
 /**
@@ -144,8 +191,9 @@ function convertDescriptor(desc: any): AlpsDescriptor {
   };
 
   // Extract doc element
-  if (desc.doc) {
-    descriptor.doc = desc.doc['#text'] || desc.doc;
+  const doc = convertDoc(desc.doc);
+  if (doc !== undefined) {
+    descriptor.doc = doc;
   }
 
   // Extract nested descriptors

--- a/packages/cli/tests/alps-parser.test.ts
+++ b/packages/cli/tests/alps-parser.test.ts
@@ -1,0 +1,32 @@
+import { parseAlpsAuto, docText } from '../src/parser/alps-parser';
+
+describe('parseAlpsAuto', () => {
+  it('parses JSON profiles', () => {
+    const doc = parseAlpsAuto('{"alps": {"title": "T", "descriptor": [{"id": "x"}]}}');
+    expect(doc.alps.title).toBe('T');
+    expect(doc.alps.descriptor?.[0].id).toBe('x');
+  });
+
+  it('parses XML doc text content', () => {
+    const doc = parseAlpsAuto(
+      '<alps><descriptor id="x"><doc>hello</doc></descriptor></alps>'
+    );
+    expect(docText(doc.alps.descriptor?.[0].doc)).toBe('hello');
+  });
+
+  it('parses XML doc href and format attributes', () => {
+    const doc = parseAlpsAuto(
+      '<alps><descriptor id="x"><doc href="alps-doc/x.md" format="markdown"/></descriptor></alps>'
+    );
+    expect(doc.alps.descriptor?.[0].doc).toEqual({ href: 'alps-doc/x.md', format: 'markdown' });
+  });
+});
+
+describe('docText', () => {
+  it('handles string, object, and undefined forms', () => {
+    expect(docText('plain')).toBe('plain');
+    expect(docText({ value: 'v' })).toBe('v');
+    expect(docText({ href: 'x.md' })).toBe('');
+    expect(docText(undefined)).toBe('');
+  });
+});

--- a/packages/cli/tests/doc-store.test.ts
+++ b/packages/cli/tests/doc-store.test.ts
@@ -1,0 +1,170 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  setDescriptorDoc,
+  resolveDoc,
+  shouldExternalize,
+  INLINE_DOC_MAX_LENGTH,
+  DOC_DIR,
+} from '../src/mcp/doc-store';
+
+const PROFILE = {
+  alps: {
+    title: 'Test',
+    descriptor: [
+      {
+        id: 'Home',
+        type: 'semantic',
+        descriptor: [{ href: '#goCatalog' }, { id: 'greeting', type: 'semantic' }],
+      },
+      { id: 'Catalog', type: 'semantic', doc: { value: 'old doc', format: 'text' } },
+      { id: 'goCatalog', type: 'safe', rt: '#Catalog' },
+    ],
+  },
+};
+
+let dir: string;
+let profilePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-store-'));
+  profilePath = path.join(dir, 'profile.json');
+  fs.writeFileSync(profilePath, JSON.stringify(PROFILE, null, 2) + '\n');
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const readProfile = () => JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+
+describe('shouldExternalize', () => {
+  it('keeps short single-line docs inline', () => {
+    expect(shouldExternalize('Short doc')).toBe(false);
+  });
+
+  it('externalizes long docs', () => {
+    expect(shouldExternalize('a'.repeat(INLINE_DOC_MAX_LENGTH + 1))).toBe(true);
+  });
+
+  it('externalizes multi-line docs', () => {
+    expect(shouldExternalize('# Title\n\nBody')).toBe(true);
+  });
+});
+
+describe('setDescriptorDoc', () => {
+  it('stores a short doc inline as a string', () => {
+    const result = setDescriptorDoc(profilePath, 'Home', 'Entry point.');
+    expect(result).toEqual({ id: 'Home', placement: 'inline' });
+    expect(readProfile().alps.descriptor[0].doc).toBe('Entry point.');
+  });
+
+  it('preserves object form when updating an existing inline doc', () => {
+    setDescriptorDoc(profilePath, 'Catalog', 'new doc');
+    expect(readProfile().alps.descriptor[1].doc).toEqual({ value: 'new doc', format: 'text' });
+  });
+
+  it('stores a large doc in an external alps-doc file linked via doc.href', () => {
+    const doc = '# Home\n\nDetailed documentation.\n\n- rule 1\n- rule 2';
+    const result = setDescriptorDoc(profilePath, 'Home', doc);
+    expect(result.placement).toBe('external');
+    expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+    expect(readProfile().alps.descriptor[0].doc).toEqual({
+      href: `${DOC_DIR}/Home.md`,
+      format: 'markdown',
+    });
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe(doc + '\n');
+  });
+
+  it('keeps an existing external doc external on auto, even for short docs', () => {
+    setDescriptorDoc(profilePath, 'Home', '# Long\n\ndoc');
+    const result = setDescriptorDoc(profilePath, 'Home', 'Now short.');
+    expect(result.placement).toBe('external');
+    expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe('Now short.\n');
+  });
+
+  it('forces inline placement and reports the orphaned doc file', () => {
+    setDescriptorDoc(profilePath, 'Home', '# Long\n\ndoc');
+    const result = setDescriptorDoc(profilePath, 'Home', 'Inline now.', 'inline');
+    expect(result).toEqual({
+      id: 'Home',
+      placement: 'inline',
+      orphanedDocFile: `${DOC_DIR}/Home.md`,
+    });
+    expect(readProfile().alps.descriptor[0].doc).toBe('Inline now.');
+    expect(fs.existsSync(path.join(dir, DOC_DIR, 'Home.md'))).toBe(true);
+  });
+
+  it('forces external placement for short docs', () => {
+    const result = setDescriptorDoc(profilePath, 'Home', 'Short.', 'external');
+    expect(result.placement).toBe('external');
+    expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+  });
+
+  it('updates nested descriptors', () => {
+    setDescriptorDoc(profilePath, 'greeting', 'A greeting.');
+    expect(readProfile().alps.descriptor[0].descriptor[1].doc).toBe('A greeting.');
+  });
+
+  it('sanitizes descriptor ids in file names', () => {
+    const profile = { alps: { descriptor: [{ id: 'a/b c', type: 'semantic' }] } };
+    fs.writeFileSync(profilePath, JSON.stringify(profile));
+    const result = setDescriptorDoc(profilePath, 'a/b c', 'x\ny');
+    expect(result.docFile).toBe(`${DOC_DIR}/a-b-c.md`);
+  });
+
+  it('preserves the original indentation', () => {
+    fs.writeFileSync(profilePath, JSON.stringify(PROFILE, null, 4) + '\n');
+    setDescriptorDoc(profilePath, 'Home', 'Doc.');
+    const content = fs.readFileSync(profilePath, 'utf-8');
+    expect(content).toContain('\n    "alps"');
+    expect(content.endsWith('\n')).toBe(true);
+  });
+
+  it('rejects unknown descriptor ids', () => {
+    expect(() => setDescriptorDoc(profilePath, 'Nope', 'doc')).toThrow('Descriptor not found');
+  });
+
+  it('rejects XML profiles', () => {
+    const xmlPath = path.join(dir, 'profile.xml');
+    fs.writeFileSync(xmlPath, '<alps><descriptor id="Home"/></alps>');
+    expect(() => setDescriptorDoc(xmlPath, 'Home', 'doc')).toThrow('JSON profiles only');
+  });
+
+  it('rejects missing files', () => {
+    expect(() => setDescriptorDoc(path.join(dir, 'none.json'), 'Home', 'doc')).toThrow(
+      'Profile file not found'
+    );
+  });
+});
+
+describe('resolveDoc', () => {
+  it('resolves inline string docs', () => {
+    expect(resolveDoc(dir, 'hello')).toEqual({ text: 'hello' });
+  });
+
+  it('reads external alps-doc files', () => {
+    setDescriptorDoc(profilePath, 'Home', '# Doc\n\nbody');
+    const resolved = resolveDoc(dir, { href: `${DOC_DIR}/Home.md`, format: 'markdown' });
+    expect(resolved).toEqual({
+      text: '# Doc\n\nbody\n',
+      href: `${DOC_DIR}/Home.md`,
+      format: 'markdown',
+    });
+  });
+
+  it('falls back to the inline value when the external file is missing', () => {
+    const resolved = resolveDoc(dir, { href: `${DOC_DIR}/missing.md`, value: 'fallback' });
+    expect(resolved?.text).toBe('fallback');
+  });
+
+  it('does not fetch http urls', () => {
+    const resolved = resolveDoc(dir, { href: 'https://example.com/doc.md', value: 'inline' });
+    expect(resolved).toEqual({ text: 'inline', href: 'https://example.com/doc.md', format: undefined });
+  });
+
+  it('returns undefined for missing docs', () => {
+    expect(resolveDoc(dir, undefined)).toBeUndefined();
+  });
+});

--- a/packages/cli/tests/doc-store.test.ts
+++ b/packages/cli/tests/doc-store.test.ts
@@ -65,7 +65,7 @@ describe('setDescriptorDoc', () => {
     expect(readProfile().alps.descriptor[1].doc).toEqual({ value: 'new doc', format: 'text' });
   });
 
-  it('stores a large doc in an external alps-doc file linked via doc.href', () => {
+  it('stores a large doc in an external alps/docs file linked via doc.href', () => {
     const doc = '# Home\n\nDetailed documentation.\n\n- rule 1\n- rule 2';
     const result = setDescriptorDoc(profilePath, 'Home', doc);
     expect(result.placement).toBe('external');
@@ -175,7 +175,7 @@ describe('resolveDoc', () => {
     expect(resolveDoc(dir, 'hello')).toEqual({ text: 'hello' });
   });
 
-  it('reads external alps-doc files', () => {
+  it('reads external doc files', () => {
     setDescriptorDoc(profilePath, 'Home', '# Doc\n\nbody');
     const resolved = resolveDoc(dir, { href: `${DOC_DIR}/Home.md`, format: 'markdown' });
     expect(resolved).toEqual({

--- a/packages/cli/tests/doc-store.test.ts
+++ b/packages/cli/tests/doc-store.test.ts
@@ -140,6 +140,29 @@ describe('setDescriptorDoc', () => {
     expect(content.endsWith('\n')).toBe(true);
   });
 
+  it('writes through symlinks that stay inside the profile directory', () => {
+    fs.mkdirSync(path.join(dir, 'real-docs'));
+    fs.symlinkSync(path.join(dir, 'real-docs'), path.join(dir, 'linkdocs'));
+    const profile = {
+      alps: { descriptor: [{ id: 'Home', type: 'semantic', doc: { href: 'linkdocs/home.md' } }] },
+    };
+    fs.writeFileSync(profilePath, JSON.stringify(profile));
+    const result = setDescriptorDoc(profilePath, 'Home', 'Linked doc.');
+    expect(result).toEqual({ id: 'Home', placement: 'external', docFile: 'linkdocs/home.md' });
+    expect(fs.readFileSync(path.join(dir, 'real-docs', 'home.md'), 'utf-8')).toBe('Linked doc.\n');
+  });
+
+  it('rejects writes through symlinks escaping the profile directory', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-store-outside-'));
+    try {
+      fs.symlinkSync(outside, path.join(dir, 'alps'));
+      expect(() => setDescriptorDoc(profilePath, 'Home', 'x\ny')).toThrow('Unsafe doc path');
+      expect(fs.readdirSync(outside)).toEqual([]);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
   it('does not reuse unsafe existing doc.href values as write targets', () => {
     const unsafeHrefs = ['../escape.md', '/etc/escape.md', 'file:///etc/escape.md', 'a\\b.md'];
     for (const href of unsafeHrefs) {
@@ -193,6 +216,18 @@ describe('resolveDoc', () => {
   it('does not fetch http urls', () => {
     const resolved = resolveDoc(dir, { href: 'https://example.com/doc.md', value: 'inline' });
     expect(resolved).toEqual({ text: 'inline', href: 'https://example.com/doc.md', format: undefined });
+  });
+
+  it('does not read through symlinks escaping the profile directory', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-store-outside-'));
+    try {
+      fs.writeFileSync(path.join(outside, 'secret.md'), 'secret');
+      fs.symlinkSync(outside, path.join(dir, 'extdocs'));
+      const resolved = resolveDoc(dir, { href: 'extdocs/secret.md', value: 'fallback' });
+      expect(resolved?.text).toBe('fallback');
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it('does not read hrefs that escape the profile directory', () => {

--- a/packages/cli/tests/doc-store.test.ts
+++ b/packages/cli/tests/doc-store.test.ts
@@ -84,6 +84,24 @@ describe('setDescriptorDoc', () => {
     expect(fs.readFileSync(path.join(dir, DOC_DIR, 'Home.md'), 'utf-8')).toBe('Now short.\n');
   });
 
+  it('updates a custom local doc.href in place, preserving its format', () => {
+    const profile = {
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', doc: { href: 'docs/home.txt', format: 'text' } },
+        ],
+      },
+    };
+    fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+    const result = setDescriptorDoc(profilePath, 'Home', 'Updated doc.');
+    expect(result).toEqual({ id: 'Home', placement: 'external', docFile: 'docs/home.txt' });
+    expect(fs.readFileSync(path.join(dir, 'docs/home.txt'), 'utf-8')).toBe('Updated doc.\n');
+    expect(readProfile().alps.descriptor[0].doc).toEqual({
+      href: 'docs/home.txt',
+      format: 'text',
+    });
+  });
+
   it('forces inline placement and reports the orphaned doc file', () => {
     setDescriptorDoc(profilePath, 'Home', '# Long\n\ndoc');
     const result = setDescriptorDoc(profilePath, 'Home', 'Inline now.', 'inline');

--- a/packages/cli/tests/doc-store.test.ts
+++ b/packages/cli/tests/doc-store.test.ts
@@ -140,6 +140,19 @@ describe('setDescriptorDoc', () => {
     expect(content.endsWith('\n')).toBe(true);
   });
 
+  it('does not reuse unsafe existing doc.href values as write targets', () => {
+    const unsafeHrefs = ['../escape.md', '/etc/escape.md', 'file:///etc/escape.md', 'a\\b.md'];
+    for (const href of unsafeHrefs) {
+      const profile = {
+        alps: { descriptor: [{ id: 'Home', type: 'semantic', doc: { href } }] },
+      };
+      fs.writeFileSync(profilePath, JSON.stringify(profile));
+      const result = setDescriptorDoc(profilePath, 'Home', 'x\ny');
+      expect(result.docFile).toBe(`${DOC_DIR}/Home.md`);
+      expect(fs.existsSync(path.join(dir, '..', 'escape.md'))).toBe(false);
+    }
+  });
+
   it('rejects unknown descriptor ids', () => {
     expect(() => setDescriptorDoc(profilePath, 'Nope', 'doc')).toThrow('Descriptor not found');
   });
@@ -180,6 +193,19 @@ describe('resolveDoc', () => {
   it('does not fetch http urls', () => {
     const resolved = resolveDoc(dir, { href: 'https://example.com/doc.md', value: 'inline' });
     expect(resolved).toEqual({ text: 'inline', href: 'https://example.com/doc.md', format: undefined });
+  });
+
+  it('does not read hrefs that escape the profile directory', () => {
+    const outside = path.join(path.dirname(dir), 'outside-secret.md');
+    fs.writeFileSync(outside, 'secret');
+    try {
+      for (const href of [`../${path.basename(outside)}`, outside, `file://${outside}`]) {
+        const resolved = resolveDoc(dir, { href, value: 'fallback' });
+        expect(resolved?.text).toBe('fallback');
+      }
+    } finally {
+      fs.rmSync(outside, { force: true });
+    }
   });
 
   it('returns undefined for missing docs', () => {

--- a/packages/cli/tests/graph.test.ts
+++ b/packages/cli/tests/graph.test.ts
@@ -44,6 +44,21 @@ describe('extractGraph', () => {
   it('does not treat plain semantic descriptors as states', () => {
     expect(graph.states.find(s => s.id === 'price')).toBeUndefined();
   });
+
+  it('excludes transitions with external rt references', () => {
+    const doc: AlpsDocument = {
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', descriptor: [{ href: '#goExt' }, { href: '#goSelf' }] },
+          { id: 'goExt', type: 'safe', rt: 'other.json#Remote' },
+          { id: 'goSelf', type: 'safe', rt: '#Home' },
+        ],
+      },
+    };
+    const g = extractGraph(doc);
+    expect(g.transitions.map(t => t.id)).toEqual(['goSelf']);
+    expect(g.states.map(s => s.id)).toEqual(['Home']);
+  });
 });
 
 describe('findContainers', () => {

--- a/packages/cli/tests/graph.test.ts
+++ b/packages/cli/tests/graph.test.ts
@@ -1,0 +1,87 @@
+import { extractGraph, findPaths, formatPath, findContainers } from '../src/mcp/graph';
+import type { AlpsDocument } from '../src/parser/alps-parser';
+
+const DOC: AlpsDocument = {
+  alps: {
+    title: 'Store',
+    descriptor: [
+      { id: 'Home', type: 'semantic', descriptor: [{ href: '#goCatalog' }, { href: '#goCart' }] },
+      {
+        id: 'Catalog',
+        type: 'semantic',
+        descriptor: [{ href: '#goHome' }, { href: '#doAddToCart' }],
+      },
+      { id: 'Cart', type: 'semantic', descriptor: [{ href: '#goCheckout' }] },
+      { id: 'Checkout', type: 'semantic' },
+      { id: 'goCatalog', type: 'safe', rt: '#Catalog' },
+      { id: 'goCart', type: 'safe', rt: '#Cart' },
+      { id: 'goHome', type: 'safe', rt: '#Home' },
+      { id: 'doAddToCart', type: 'unsafe', rt: '#Cart' },
+      { id: 'goCheckout', type: 'safe', rt: '#Checkout' },
+      { id: 'price', type: 'semantic' },
+    ],
+  },
+};
+
+describe('extractGraph', () => {
+  const graph = extractGraph(DOC);
+
+  it('extracts states (rt targets and transition containers)', () => {
+    expect(graph.states.map(s => s.id).sort()).toEqual(['Cart', 'Catalog', 'Checkout', 'Home']);
+  });
+
+  it('extracts transitions with from/to', () => {
+    const addToCart = graph.transitions.find(t => t.id === 'doAddToCart');
+    expect(addToCart).toEqual({
+      id: 'doAddToCart',
+      type: 'unsafe',
+      title: undefined,
+      from: ['Catalog'],
+      to: 'Cart',
+    });
+  });
+
+  it('does not treat plain semantic descriptors as states', () => {
+    expect(graph.states.find(s => s.id === 'price')).toBeUndefined();
+  });
+});
+
+describe('findContainers', () => {
+  it('finds all containers of a descriptor', () => {
+    expect(findContainers('goHome', DOC.alps.descriptor!)).toEqual(['Catalog']);
+  });
+
+  it('returns an empty array when not contained', () => {
+    expect(findContainers('price', DOC.alps.descriptor!)).toEqual([]);
+  });
+});
+
+describe('findPaths', () => {
+  const graph = extractGraph(DOC);
+
+  it('enumerates all paths between two states', () => {
+    const paths = findPaths(graph, 'Home', 'Checkout');
+    const formatted = paths.map(p => formatPath('Home', p)).sort();
+    expect(formatted).toEqual([
+      'Home --goCart(safe)--> Cart --goCheckout(safe)--> Checkout',
+      'Home --goCatalog(safe)--> Catalog --doAddToCart(unsafe)--> Cart --goCheckout(safe)--> Checkout',
+    ]);
+  });
+
+  it('does not revisit states (no infinite loops on cycles)', () => {
+    const paths = findPaths(graph, 'Catalog', 'Checkout');
+    const formatted = paths.map(p => formatPath('Catalog', p)).sort();
+    expect(formatted).toEqual([
+      'Catalog --doAddToCart(unsafe)--> Cart --goCheckout(safe)--> Checkout',
+      'Catalog --goHome(safe)--> Home --goCart(safe)--> Cart --goCheckout(safe)--> Checkout',
+    ]);
+  });
+
+  it('returns an empty array when no path exists', () => {
+    expect(findPaths(graph, 'Checkout', 'Home')).toEqual([]);
+  });
+
+  it('respects maxPaths', () => {
+    expect(findPaths(graph, 'Home', 'Checkout', 1).length).toBe(1);
+  });
+});

--- a/packages/cli/tests/validator.test.ts
+++ b/packages/cli/tests/validator.test.ts
@@ -1,0 +1,117 @@
+import { validateAlps } from '../src/mcp/validator';
+import type { AlpsDocument } from '../src/parser/alps-parser';
+
+const codes = (issues: { code: string }[]) => issues.map(i => i.code);
+
+describe('validateAlps', () => {
+  it('accepts a valid profile', () => {
+    const doc: AlpsDocument = {
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', descriptor: [{ href: '#goHome' }] },
+          { id: 'goHome', type: 'safe', rt: '#Home' },
+        ],
+      },
+    };
+    const result = validateAlps(doc);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports a missing alps property (E008)', () => {
+    const result = validateAlps({} as AlpsDocument);
+    expect(codes(result.errors)).toContain('E008');
+  });
+
+  it('reports a missing descriptor array (E009)', () => {
+    const result = validateAlps({ alps: {} });
+    expect(codes(result.errors)).toContain('E009');
+  });
+
+  it('reports descriptors without id or href (E001)', () => {
+    const result = validateAlps({ alps: { descriptor: [{ type: 'semantic' }] } });
+    expect(codes(result.errors)).toContain('E001');
+  });
+
+  it('reports a transition without rt (E002)', () => {
+    const result = validateAlps({ alps: { descriptor: [{ id: 'goX', type: 'safe' }] } });
+    expect(codes(result.errors)).toContain('E002');
+  });
+
+  it('reports invalid types (E003)', () => {
+    const result = validateAlps({
+      alps: { descriptor: [{ id: 'x', type: 'bogus' as never }] },
+    });
+    expect(codes(result.errors)).toContain('E003');
+  });
+
+  it('reports broken rt references (E004)', () => {
+    const result = validateAlps({
+      alps: { descriptor: [{ id: 'goX', type: 'safe', rt: '#Missing' }] },
+    });
+    expect(codes(result.errors)).toContain('E004');
+  });
+
+  it('reports broken local href references (E004)', () => {
+    const result = validateAlps({
+      alps: {
+        descriptor: [{ id: 'Home', type: 'semantic', descriptor: [{ href: '#missing' }] }],
+      },
+    });
+    expect(codes(result.errors)).toContain('E004');
+  });
+
+  it('ignores external file references', () => {
+    const result = validateAlps({
+      alps: {
+        descriptor: [{ id: 'Home', type: 'semantic', descriptor: [{ href: 'common.json#id' }] }],
+      },
+    });
+    expect(codes(result.errors)).not.toContain('E004');
+  });
+
+  it('reports duplicate ids (E005)', () => {
+    const result = validateAlps({
+      alps: { descriptor: [{ id: 'x', type: 'semantic' }, { id: 'x', type: 'semantic' }] },
+    });
+    expect(codes(result.errors)).toContain('E005');
+  });
+
+  it('warns on safe transitions not starting with go (W002)', () => {
+    const result = validateAlps({
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', descriptor: [{ href: '#listItems' }] },
+          { id: 'listItems', type: 'safe', rt: '#Home' },
+        ],
+      },
+    });
+    expect(codes(result.warnings)).toContain('W002');
+  });
+
+  it('warns on unsafe transitions not starting with do (W003)', () => {
+    const result = validateAlps({
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', descriptor: [{ href: '#addItem' }] },
+          { id: 'addItem', type: 'unsafe', rt: '#Home' },
+        ],
+      },
+    });
+    expect(codes(result.warnings)).toContain('W003');
+  });
+
+  it('warns on orphan descriptors (W004)', () => {
+    const result = validateAlps({
+      alps: {
+        descriptor: [
+          { id: 'Home', type: 'semantic', descriptor: [{ href: '#goHome' }] },
+          { id: 'goHome', type: 'safe', rt: '#Home' },
+          { id: 'lonely', type: 'semantic' },
+        ],
+      },
+    });
+    const orphans = result.warnings.filter(w => w.code === 'W004');
+    expect(orphans.map(w => w.descriptorId)).toEqual(['lonely']);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@viz-js/viz':
         specifier: ^3.11.0
         version: 3.23.0
@@ -41,6 +44,9 @@ importers:
       fast-xml-parser:
         specifier: ^4.5.0
         version: 4.5.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/chrome-remote-interface':
         specifier: ^0.33.0
@@ -228,6 +234,12 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -337,6 +349,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -501,6 +523,21 @@ packages:
   '@viz-js/viz@3.23.0':
     resolution: {integrity: sha512-TwtwForv4xmMqJZFOFgfCJDAI3mKP3eXPq0CrdGPO9IwXeRl7pEDu1sxz4zGU+r2HkTuVxtTBjSEvk/ogD7Giw==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -568,6 +605,10 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -592,6 +633,18 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -659,8 +712,32 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -687,6 +764,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -694,8 +775,15 @@ packages:
   devtools-protocol@0.0.1173815:
     resolution: {integrity: sha512-CmsjkudmgCMeae8FSJB4GV8COZwOk6dJKyE9HS2F/ih/sA8uTdbPKHg5F7DsrOYLEET/QKK00LJCU4YoyG+uHg==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
@@ -710,12 +798,31 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -725,6 +832,18 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -738,8 +857,24 @@ packages:
     resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-parser@4.5.3:
     resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
@@ -752,6 +887,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -759,6 +898,14 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -768,6 +915,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -776,9 +926,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -796,6 +954,10 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -808,12 +970,32 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
@@ -830,6 +1012,14 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -857,6 +1047,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -1016,6 +1209,9 @@ packages:
       node-notifier:
         optional: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1030,6 +1226,12 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1066,12 +1268,32 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1102,6 +1324,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -1118,6 +1344,18 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1149,6 +1387,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1165,6 +1407,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1180,6 +1425,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -1188,8 +1437,24 @@ packages:
     resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -1202,6 +1467,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -1209,6 +1478,13 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1219,6 +1495,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1226,6 +1513,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1251,6 +1554,10 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -1310,6 +1617,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-jest@29.4.6:
     resolution: {integrity: sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -1352,6 +1663,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1365,6 +1680,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -1377,6 +1696,10 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -1434,6 +1757,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1641,6 +1972,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@hono/node-server@1.19.14(hono@4.12.25)':
+    dependencies:
+      hono: 4.12.25
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -1859,6 +2194,28 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.25)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.25
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
@@ -2001,6 +2358,22 @@ snapshots:
 
   '@viz-js/viz@3.23.0': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -2084,6 +2457,20 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -2114,6 +2501,18 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -2176,7 +2575,22 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2192,11 +2606,21 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  depd@2.0.0: {}
+
   detect-newline@3.1.0: {}
 
   devtools-protocol@0.0.1173815: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.267: {}
 
@@ -2206,15 +2630,35 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@2.0.0: {}
 
   esprima@4.0.1: {}
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -2239,7 +2683,49 @@ snapshots:
       jest-mock: 30.2.0
       jest-util: 30.2.0
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.2: {}
 
   fast-xml-parser@4.5.3:
     dependencies:
@@ -2253,6 +2739,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -2263,16 +2760,40 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-stream@6.0.1: {}
 
@@ -2298,6 +2819,8 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   handlebars@4.7.8:
@@ -2311,9 +2834,29 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.25: {}
+
   html-escaper@2.0.2: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-signals@2.1.0: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   import-local@3.2.0:
     dependencies:
@@ -2328,6 +2871,10 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
 
@@ -2346,6 +2893,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -2699,6 +3248,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -2709,6 +3260,10 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -2738,12 +3293,24 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -2765,6 +3332,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   neo-async@2.6.2: {}
 
   node-int64@0.4.0: {}
@@ -2776,6 +3345,14 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -2808,6 +3385,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -2819,6 +3398,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-to-regexp@8.4.2: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -2826,6 +3407,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
     dependencies:
@@ -2837,7 +3420,25 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pure-rand@7.0.1: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-is@18.3.1: {}
 
@@ -2847,21 +3448,90 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
 
   resolve-from@5.0.0: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7: {}
 
@@ -2881,6 +3551,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  statuses@2.0.2: {}
 
   string-length@4.0.2:
     dependencies:
@@ -2939,6 +3611,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.26))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -2968,12 +3642,20 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   uglify-js@3.19.3:
     optional: true
 
   undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -3010,6 +3692,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  vary@1.1.2: {}
 
   walker@1.0.8:
     dependencies:
@@ -3059,3 +3743,9 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,18 @@ importers:
       '@types/chrome-remote-interface':
         specifier: ^0.33.0
         version: 0.33.0
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^20.8.0
         version: 20.19.26
+      jest:
+        specifier: ^30.2.0
+        version: 30.2.0(@types/node@20.19.26)
+      ts-jest:
+        specifier: ^29.4.6
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.26))(typescript@5.9.3)
       typescript:
         specifier: ^5.2.2
         version: 5.9.3
@@ -424,6 +433,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -948,11 +958,12 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}


### PR DESCRIPTION
## Summary

Adds `asd --mcp`, running the CLI as an MCP server (stdio) so AI agents can query and modify ALPS profiles incrementally — instead of the one-shot file→file conversion the CLI does for humans.

### Tools

| Tool | Description |
|------|-------------|
| `alps_overview` | Profile summary: states, transitions (from/to), tags |
| `alps_validate` | Validation with E/W codes following the README conventions |
| `alps_search` | Filter descriptors by type, tag, or free text |
| `alps_descriptor` | Full descriptor details with resolved documentation |
| `alps_paths` | Enumerate transition paths between two states |
| `alps_diagram` | Render the state diagram as DOT or SVG |
| `alps_set_doc` | Set descriptor documentation with automatic placement |

### Doc externalization (`alps-doc/`)

The core feature of `alps_set_doc`: short single-line docs stay inline, but when the server judges a doc to be large (>200 chars or multi-line Markdown), it is written to `alps-doc/<descriptor-id>.md` next to the profile and linked via the ALPS `doc` element's `href`:

```json
"doc": { "href": "alps-doc/ShoppingCart.md", "format": "markdown" }
```

This keeps profiles compact while allowing rich, detailed documentation of each state's meaning and related information. Read tools (`alps_descriptor`) resolve the link and inline the file content transparently. Descriptors already using an `alps-doc/` file stay external on update (no inline/external churn); switching to inline never deletes the old file, only reports it as orphaned.

### Supporting changes

- XML parser now preserves `<doc href format/>` attributes; `AlpsDoc` type covers the href form
- Jest setup for `@alps-asd/cli` with 46 tests (doc-store, graph, validator, parser)
- ADR 0003 documents the design; ADR 0002's "keep MCP in PHP" decision is superseded
- Fixed broken `docs/architecture.md` links (file lives at `dev-docs/architecture.md`)

### Notes

- `alps_set_doc` edits the raw JSON (not the normalized parse), preserving the rest of the profile including indentation style. Writing is JSON-only for now; read tools support both JSON and XML.
- SDK is imported as `@modelcontextprotocol/sdk/server/mcp.js` — the only form that resolves both at runtime (package `exports`) and for types (`typesVersions`) under `moduleResolution: node`.
- Rendering linked docs in HTML output is future work.

## Test plan

- [x] `pnpm --filter @alps-asd/cli test` — 46 tests pass
- [x] `pnpm --filter @alps-asd/cli build` — clean compile
- [x] End-to-end stdio JSON-RPC session: initialize → tools/list → all 7 tools exercised, including auto-externalization to `alps-doc/Cart.md` and resolved read-back
- [x] Regression: `asd dev-docs/bookstore/alps.xml -e -m dot` unchanged

https://claude.ai/code/session_01GgtBKQhCEPnyKUjx62izxK

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgtBKQhCEPnyKUjx62izxK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server via new CLI flag, exposing ALPS profiles and seven MCP tools (overview, validate, search, descriptor, paths, diagram, set_doc). Externalized descriptor docs support (separate markdown storage and inlining).

* **Documentation**
  * README, ADRs, and architecture docs updated with MCP usage, tools, config examples, and doc-storage conventions.

* **Tests**
  * New comprehensive test suites for parser, doc-store, graph, and validator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->